### PR TITLE
Fix ExecuteTurn1Combined S3 path handling

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/cmd/main.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/cmd/main.go
@@ -227,7 +227,7 @@ type ServiceLayerComponents struct {
 // with deterministic local Bedrock control architecture
 func initializeServiceLayerWithLocalBedrock(awsConfig aws.Config, cfg *internalConfig.Config, logger logger.Logger) (*ServiceLayerComponents, error) {
 	// S3 service initialization
-	s3Service, err := services.NewS3StateManager(cfg.AWS.S3Bucket, logger)
+	s3Service, err := services.NewS3StateManager(*cfg, logger)
 	if err != nil {
 		return nil, errors.WrapError(err, errors.ErrorTypeS3,
 			"S3 service initialization failed", false)

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/config/validate.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/config/validate.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"time"
 	"workflow-function/shared/errors"
 )
 
@@ -29,6 +30,14 @@ func (c *Config) Validate() error {
 			"BedrockTimeoutInvalid",
 			"Bedrock call timeout must be greater than connect timeout",
 			"BEDROCK_CALL_TIMEOUT_SEC",
+		)
+	}
+
+	if _, err := time.LoadLocation(c.DatePartitionTimezone); err != nil {
+		return errors.NewConfigError(
+			"InvalidTimezone",
+			"invalid timezone",
+			"DATE_PARTITION_TIMEZONE",
 		)
 	}
 


### PR DESCRIPTION
## Summary
- support date-based S3 partitioning in ExecuteTurn1Combined
- validate timezone in config
- store prompts via new S3 method
- adjust storage paths to include date prefix

## Testing
- `go test ./...` *(fails: directory prefix does not contain modules)*