### PR TITLE
Fix ExecuteTurn1Combined prompt/response schema

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/handler_helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/handler_helpers.go
@@ -162,8 +162,8 @@ func (h *Handler) recordBedrockSuccess(ctx context.Context, verificationID strin
 }
 
 // recordStorageSuccess records successful storage operations
-func (h *Handler) recordStorageSuccess(result *StorageResult, responseSize int) {
-	metadata := h.storageManager.GetStorageMetadata(result, responseSize)
+func (h *Handler) recordStorageSuccess(result *StorageResult) {
+	metadata := h.storageManager.GetStorageMetadata(result)
 	h.processingTracker.RecordStage("response_processing", "completed", result.Duration, metadata)
 }
 

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/storage_manager.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/storage_manager.go
@@ -2,13 +2,16 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
+
 	"workflow-function/ExecuteTurn1Combined/internal/config"
 	"workflow-function/ExecuteTurn1Combined/internal/models"
 	"workflow-function/ExecuteTurn1Combined/internal/services"
 	"workflow-function/shared/errors"
 	"workflow-function/shared/logger"
+	"workflow-function/shared/schema"
 )
 
 // StorageManager handles S3 storage operations for responses
@@ -31,28 +34,81 @@ func NewStorageManager(s3 services.S3StateManager, cfg config.Config, log logger
 type StorageResult struct {
 	RawRef       models.S3Reference
 	ProcessedRef models.S3Reference
+	RawSize      int
 	Duration     time.Duration
 	Error        error
 }
 
-// StorePrompt stores the rendered prompt to S3
-func (m *StorageManager) StorePrompt(ctx context.Context, verifID string, turn int, prompt string) (models.S3Reference, error) {
+// StorePrompt stores the rendered prompt in structured schema format
+func (m *StorageManager) StorePrompt(ctx context.Context, req *models.Turn1Request, turn int, result *PromptResult) (models.S3Reference, error) {
 	key := fmt.Sprintf("prompts/turn%d-prompt.json", turn)
 
-	promptData := map[string]string{"prompt": prompt}
-	contextLogger := m.log.WithCorrelationId(verifID)
+	contextLogger := m.log.WithCorrelationId(req.VerificationID)
 
-	ref, err := m.s3.StorePrompt(ctx, verifID, turn, promptData)
+	// Build message structure for Bedrock
+	messageStructure := map[string]interface{}{
+		"role":    "user",
+		"content": []map[string]interface{}{{"type": "text", "text": result.Prompt}},
+	}
+
+	// Build contextual instructions - minimal for now
+	contextual := map[string]interface{}{
+		"analysisObjective": "Analyze reference image in detail",
+	}
+
+	// Build image reference with base64 location
+	imageRef := map[string]interface{}{
+		"imageType": "reference",
+		"base64StorageReference": map[string]interface{}{
+			"bucket": req.S3Refs.Images.ReferenceBase64.Bucket,
+			"key":    req.S3Refs.Images.ReferenceBase64.Key,
+		},
+	}
+	if url, ok := req.VerificationContext.LayoutMetadata["referenceImageUrl"].(string); ok && url != "" {
+		imageRef["sourceUrl"] = url
+	} else {
+		imageRef["sourceUrl"] = req.S3Refs.Images.ReferenceBase64.Key
+	}
+
+	// Determine context sources
+	contextSources := []string{"INITIALIZATION", "IMAGE_METADATA"}
+	if req.VerificationContext.LayoutMetadata != nil {
+		contextSources = append(contextSources, "LAYOUT_METADATA")
+	}
+	if req.VerificationContext.HistoricalContext != nil {
+		contextSources = append(contextSources, "HISTORICAL_CONTEXT")
+	}
+
+	// Generation metadata
+	generationMetadata := map[string]interface{}{
+		"processingTimeMs": result.Duration.Milliseconds(),
+		"promptSource":     "TEMPLATE_BASED",
+		"contextSources":   contextSources,
+	}
+
+	promptData := map[string]interface{}{
+		"verificationId":         req.VerificationID,
+		"promptType":             "TURN1",
+		"verificationType":       req.VerificationContext.VerificationType,
+		"messageStructure":       messageStructure,
+		"contextualInstructions": contextual,
+		"imageReference":         imageRef,
+		"templateVersion":        m.cfg.Prompts.TemplateVersion,
+		"createdAt":              schema.FormatISO8601(),
+		"generationMetadata":     generationMetadata,
+	}
+
+	ref, err := m.s3.StorePrompt(ctx, req.VerificationID, turn, promptData)
 	if err != nil {
 		s3Err := errors.WrapError(err, errors.ErrorTypeS3,
 			"store prompt failed", true).
-			WithContext("verification_id", verifID).
-			WithContext("prompt_size", len(prompt))
+			WithContext("verification_id", req.VerificationID).
+			WithContext("prompt_size", len(result.Prompt))
 
-		enrichedErr := errors.SetVerificationID(s3Err, verifID)
+		enrichedErr := errors.SetVerificationID(s3Err, req.VerificationID)
 
 		contextLogger.Warn("s3 prompt-store warning", map[string]interface{}{
-			"prompt_size_bytes": len(prompt),
+			"prompt_size_bytes": len(result.Prompt),
 			"bucket":            m.cfg.AWS.S3Bucket,
 			"key":               key,
 		})
@@ -62,7 +118,7 @@ func (m *StorageManager) StorePrompt(ctx context.Context, verifID string, turn i
 
 	contextLogger.Debug("stored prompt", map[string]interface{}{
 		"key":        ref.Key,
-		"size_bytes": len(prompt),
+		"size_bytes": len(result.Prompt),
 		"turn_id":    turn,
 	})
 
@@ -70,23 +126,70 @@ func (m *StorageManager) StorePrompt(ctx context.Context, verifID string, turn i
 }
 
 // StoreResponses stores raw and processed responses to S3
-func (s *StorageManager) StoreResponses(ctx context.Context, verificationID string, resp *models.BedrockResponse) *StorageResult {
+func (s *StorageManager) StoreResponses(ctx context.Context, req *models.Turn1Request, invoke *InvokeResult, prompt *PromptResult, imageSize int) *StorageResult {
 	startTime := time.Now()
 	result := &StorageResult{}
+	verificationID := req.VerificationID
+	resp := invoke.Response
 	contextLogger := s.log.WithCorrelationId(verificationID)
 
-	// Store raw response
-	rawRef, err := s.s3.StoreRawResponse(ctx, verificationID, resp.Raw)
+	// Build raw response structure according to schema
+	var stopReason string
+	var rawMap map[string]interface{}
+	if err := json.Unmarshal(resp.Raw, &rawMap); err == nil {
+		if sr, ok := rawMap["stop_reason"].(string); ok {
+			stopReason = sr
+		} else if sr, ok := rawMap["stopReason"].(string); ok {
+			stopReason = sr
+		}
+	}
+
+	rawData := map[string]interface{}{
+		"verificationId":   verificationID,
+		"turnId":           1,
+		"analysisStage":    "REFERENCE_ANALYSIS",
+		"verificationType": req.VerificationContext.VerificationType,
+		"response": map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": resp.Processed.(map[string]interface{})["content"]}},
+		},
+		"tokenUsage": map[string]interface{}{
+			"input":    resp.TokenUsage.InputTokens,
+			"output":   resp.TokenUsage.OutputTokens,
+			"thinking": resp.TokenUsage.ThinkingTokens,
+			"total":    resp.TokenUsage.TotalTokens,
+		},
+		"latencyMs": invoke.Duration.Milliseconds(),
+		"bedrockMetadata": map[string]interface{}{
+			"modelId":    s.cfg.AWS.BedrockModel,
+			"requestId":  resp.RequestID,
+			"stopReason": stopReason,
+		},
+		"promptMetadata": map[string]interface{}{
+			"imageType":           "reference",
+			"promptTokenEstimate": prompt.TemplateProcessor.TokenEstimate,
+			"imageSize":           imageSize,
+		},
+		"timestamp": schema.FormatISO8601(),
+		"status":    "SUCCESS",
+		"processingMetadata": map[string]interface{}{
+			"executionTimeMs": invoke.Duration.Milliseconds(),
+			"retryAttempts":   0,
+		},
+	}
+
+	rawJSON, _ := json.Marshal(rawData)
+	// Store raw response in new structured format
+	rawRef, err := s.s3.StoreRawResponse(ctx, verificationID, rawData)
 	if err != nil {
 		s3Err := errors.WrapError(err, errors.ErrorTypeS3,
 			"store raw response failed", true).
 			WithContext("verification_id", verificationID).
-			WithContext("response_size", len(resp.Raw))
+			WithContext("response_size", len(rawJSON))
 
 		enrichedErr := errors.SetVerificationID(s3Err, verificationID)
 
 		contextLogger.Warn("s3 raw-store warning", map[string]interface{}{
-			"response_size_bytes": len(resp.Raw),
+			"response_size_bytes": len(rawJSON),
 			"bucket":              s.cfg.AWS.S3Bucket,
 		})
 
@@ -115,16 +218,17 @@ func (s *StorageManager) StoreResponses(ctx context.Context, verificationID stri
 
 	result.RawRef = rawRef
 	result.ProcessedRef = procRef
+	result.RawSize = len(rawJSON)
 	result.Duration = time.Since(startTime)
 
 	return result
 }
 
 // GetStorageMetadata returns metadata for tracking storage operations
-func (s *StorageManager) GetStorageMetadata(result *StorageResult, respSize int) map[string]interface{} {
+func (s *StorageManager) GetStorageMetadata(result *StorageResult) map[string]interface{} {
 	return map[string]interface{}{
 		"s3_objects_created": 2,
-		"raw_response_size":  respSize,
+		"raw_response_size":  result.RawSize,
 		"processed_ref_key":  result.ProcessedRef.Key,
 		"raw_ref_key":        result.RawRef.Key,
 	}


### PR DESCRIPTION
## Summary
- output Turn1 prompt using structured schema
- build structured raw response for Turn1
- track raw response size for metadata
- update helpers to use new storage metadata

## Testing
- `go test ./...` *(fails: no network)*
- `go vet ./...` *(fails: no network)*