### PR TITLE
Fix DynamoDB update flag propagation

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the ExecuteTurn1Combined function will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.3] - 2025-05-28
+
+### Fixed
+- **DynamoDB Flag Accuracy**: `summary.dynamodbUpdated` now reflects the real
+  outcome of DynamoDB writes.
+
 ## [2.2.2] - 2025-05-24
 
 ### Fixed

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager.go
@@ -2,134 +2,49 @@ package handler
 
 import (
 	"context"
-	"time"
+
 	"workflow-function/ExecuteTurn1Combined/internal/config"
-	"workflow-function/ExecuteTurn1Combined/internal/models"
 	"workflow-function/ExecuteTurn1Combined/internal/services"
-	"workflow-function/shared/errors"
 	"workflow-function/shared/logger"
 	"workflow-function/shared/schema"
 )
 
-// DynamoManager handles DynamoDB operations
+// DynamoManager wraps DynamoDB operations used by the handler.
 type DynamoManager struct {
 	dynamo services.DynamoDBService
-	cfg    config.Config
 	log    logger.Logger
 }
 
-// NewDynamoManager creates a new instance of DynamoManager
-func NewDynamoManager(dynamo services.DynamoDBService, cfg config.Config, log logger.Logger) *DynamoManager {
-	return &DynamoManager{
-		dynamo: dynamo,
-		cfg:    cfg,
-		log:    log,
-	}
+// NewDynamoManager creates a DynamoManager instance.
+func NewDynamoManager(dynamo services.DynamoDBService, _ config.Config, log logger.Logger) *DynamoManager {
+	return &DynamoManager{dynamo: dynamo, log: log}
 }
 
-// UpdateAsync performs asynchronous DynamoDB updates
-func (d *DynamoManager) UpdateAsync(
+// Update writes the final status and conversation turn. It returns true
+// only if both writes succeed.
+func (d *DynamoManager) Update(
 	ctx context.Context,
 	verificationID string,
-	tokenUsage models.TokenUsage,
-	requestID string,
-	rawRef, procRef models.S3Reference,
-) (<-chan error, *bool) {
-	updateComplete := make(chan error, 2)
-	dynamoOK := new(bool)
-	*dynamoOK = true // Initialize to true
-	contextLogger := d.log.WithCorrelationId(verificationID)
+	statusEntry schema.StatusHistoryEntry,
+	turnEntry *schema.TurnResponse,
+) bool {
+	dynamoOK := true
 
-	go func() {
-		// Build status entry using schema types
-		statusEntry := schema.StatusHistoryEntry{
-			Status:           schema.StatusTurn1Completed,
-			Timestamp:        schema.FormatISO8601(),
-			FunctionName:     "ExecuteTurn1Combined",
-			ProcessingTimeMs: 0, // Will be set by caller
-			Stage:            "turn1_completion",
-		}
-
-		// Update verification status with enhanced method
-		updateErr := d.dynamo.UpdateVerificationStatusEnhanced(ctx, verificationID, statusEntry)
-		if updateErr != nil {
-			asyncLogger := contextLogger.WithFields(map[string]interface{}{
-				"async_operation": "verification_status_update",
-				"table":           d.cfg.AWS.DynamoDBVerificationTable,
-			})
-
-			if workflowErr, ok := updateErr.(*errors.WorkflowError); ok {
-				asyncLogger.Warn("dynamodb status update failed", map[string]interface{}{
-					"error_type": string(workflowErr.Type),
-					"error_code": workflowErr.Code,
-					"retryable":  workflowErr.Retryable,
-				})
-			} else {
-				asyncLogger.Warn("dynamodb status update failed", map[string]interface{}{
-					"error": updateErr.Error(),
-				})
-			}
-			
-			// Set dynamoOK flag to false on error
-			*dynamoOK = false
-		}
-		updateComplete <- updateErr
-
-		// Build turn response for conversation history
-		turnResponse := &schema.TurnResponse{
-			TurnId:     1,
-			Timestamp:  schema.FormatISO8601(),
-			Prompt:     "", // Would be filled with actual prompt
-			ImageUrls:  map[string]string{},
-			Response:   schema.BedrockApiResponse{RequestId: requestID},
-			LatencyMs:  0, // Will be set by caller
-			TokenUsage: &tokenUsage,
-			Stage:      "REFERENCE_ANALYSIS",
-			Metadata: map[string]interface{}{
-				"model_id":        d.cfg.AWS.BedrockModel,
-				"verification_id": verificationID,
-				"function_name":   "ExecuteTurn1Combined",
-			},
-		}
-
-		// Update conversation turn with the method available in the interface
-		historyErr := d.dynamo.UpdateConversationTurn(ctx, verificationID, turnResponse)
-		if historyErr != nil {
-			contextLogger.Warn("conversation history recording failed", map[string]interface{}{
-				"error": historyErr.Error(),
-				"table": d.cfg.AWS.DynamoDBConversationTable,
-			})
-			
-			// Set dynamoOK flag to false on error
-			*dynamoOK = false
-		}
-		updateComplete <- historyErr
-	}()
-
-	return updateComplete, dynamoOK
-}
-
-// WaitForUpdates waits for async updates with timeout
-func (d *DynamoManager) WaitForUpdates(updateComplete <-chan error, timeout time.Duration, contextLogger logger.Logger) {
-	updateTimeout := time.After(timeout)
-	updatesReceived := 0
-
-	for updatesReceived < 2 {
-		select {
-		case err := <-updateComplete:
-			updatesReceived++
-			if err != nil {
-				contextLogger.Warn("async update error received", map[string]interface{}{
-					"update_number": updatesReceived,
-					"error":         err.Error(),
-				})
-			}
-		case <-updateTimeout:
-			contextLogger.Warn("async updates timed out", map[string]interface{}{
-				"updates_received": updatesReceived,
-				"timeout_seconds":  timeout.Seconds(),
-			})
-			return
-		}
+	if err := d.dynamo.UpdateVerificationStatusEnhanced(ctx, verificationID, statusEntry); err != nil {
+		d.log.Warn("dynamodb status update failed", map[string]interface{}{
+			"error":     err.Error(),
+			"retryable": services.IsRetryable(err),
+		})
+		dynamoOK = false
 	}
+
+	if err := d.dynamo.UpdateConversationTurn(ctx, verificationID, turnEntry); err != nil {
+		d.log.Warn("conversation history recording failed", map[string]interface{}{
+			"error":     err.Error(),
+			"retryable": services.IsRetryable(err),
+		})
+		dynamoOK = false
+	}
+
+	return dynamoOK
 }

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager_test.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager_test.go
@@ -1,0 +1,80 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"workflow-function/ExecuteTurn1Combined/internal/config"
+	"workflow-function/ExecuteTurn1Combined/internal/models"
+	"workflow-function/ExecuteTurn1Combined/internal/services"
+	"workflow-function/shared/logger"
+	"workflow-function/shared/schema"
+)
+
+type mockDynamo struct {
+	statusErr error
+	turnErr   error
+}
+
+func (m *mockDynamo) UpdateVerificationStatus(ctx context.Context, verificationID string, status models.VerificationStatus, metrics models.TokenUsage) error {
+	return nil
+}
+func (m *mockDynamo) RecordConversationTurn(ctx context.Context, turn *models.ConversationTurn) error {
+	return nil
+}
+func (m *mockDynamo) UpdateVerificationStatusEnhanced(ctx context.Context, verificationID string, entry schema.StatusHistoryEntry) error {
+	return m.statusErr
+}
+func (m *mockDynamo) RecordConversationHistory(ctx context.Context, ct *schema.ConversationTracker) error {
+	return nil
+}
+func (m *mockDynamo) UpdateProcessingMetrics(ctx context.Context, verificationID string, metrics *schema.ProcessingMetrics) error {
+	return nil
+}
+func (m *mockDynamo) UpdateStatusHistory(ctx context.Context, verificationID string, statusHistory []schema.StatusHistoryEntry) error {
+	return nil
+}
+func (m *mockDynamo) UpdateErrorTracking(ctx context.Context, verificationID string, errorTracking *schema.ErrorTracking) error {
+	return nil
+}
+func (m *mockDynamo) InitializeVerificationRecord(ctx context.Context, verificationContext *schema.VerificationContext) error {
+	return nil
+}
+func (m *mockDynamo) UpdateCurrentStatus(ctx context.Context, verificationID, currentStatus, lastUpdatedAt string, metrics map[string]interface{}) error {
+	return nil
+}
+func (m *mockDynamo) GetVerificationStatus(ctx context.Context, verificationID string) (*services.VerificationStatusInfo, error) {
+	return nil, nil
+}
+func (m *mockDynamo) InitializeConversationHistory(ctx context.Context, verificationID string, maxTurns int, metadata map[string]interface{}) error {
+	return nil
+}
+func (m *mockDynamo) UpdateConversationTurn(ctx context.Context, verificationID string, turnData *schema.TurnResponse) error {
+	return m.turnErr
+}
+func (m *mockDynamo) CompleteConversation(ctx context.Context, verificationID string, finalStatus string) error {
+	return nil
+}
+func (m *mockDynamo) QueryPreviousVerification(ctx context.Context, checkingImageUrl string) (*schema.VerificationContext, error) {
+	return nil, nil
+}
+func (m *mockDynamo) GetLayoutMetadata(ctx context.Context, layoutID int, layoutPrefix string) (*schema.LayoutMetadata, error) {
+	return nil, nil
+}
+
+func TestDynamoManagerUpdateSuccess(t *testing.T) {
+	mgr := NewDynamoManager(&mockDynamo{}, config.Config{}, logger.New("test", "test"))
+	ok := mgr.Update(context.Background(), "id", schema.StatusHistoryEntry{}, &schema.TurnResponse{})
+	if !ok {
+		t.Errorf("expected true on success")
+	}
+}
+
+func TestDynamoManagerUpdateFailure(t *testing.T) {
+	mgr := NewDynamoManager(&mockDynamo{statusErr: errors.New("fail")}, config.Config{}, logger.New("test", "test"))
+	ok := mgr.Update(context.Background(), "id", schema.StatusHistoryEntry{}, &schema.TurnResponse{})
+	if ok {
+		t.Errorf("expected false on failure")
+	}
+}

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/helpers.go
@@ -26,9 +26,9 @@ type PromptReferences struct {
 
 // ImageReferences holds S3 references for image artifacts
 type ImageReferences struct {
-	Metadata   models.S3Reference `json:"metadata,omitempty"`
-	Reference  models.S3Reference `json:"reference,omitempty"`
-	Checking   models.S3Reference `json:"checking,omitempty"`
+	Metadata  models.S3Reference `json:"metadata,omitempty"`
+	Reference models.S3Reference `json:"reference,omitempty"`
+	Checking  models.S3Reference `json:"checking,omitempty"`
 }
 
 // ProcessingReferences holds S3 references for processing artifacts
@@ -73,31 +73,31 @@ func buildS3RefTree(
 ) S3ReferenceTree {
 	// Extract verification ID from the key pattern
 	verificationID := extractVerificationID(rawRef.Key)
-	
+
 	// Create initialization reference
 	initRef := models.S3Reference{
 		Bucket: rawRef.Bucket,
 		Key:    fmt.Sprintf("%s/initialization.json", verificationID),
 	}
-	
+
 	// Create images metadata reference
 	imagesMetadataRef := models.S3Reference{
 		Bucket: rawRef.Bucket,
 		Key:    fmt.Sprintf("%s/images/metadata.json", verificationID),
 	}
-	
+
 	// Create layout metadata reference for LAYOUT_VS_CHECKING
 	layoutMetadataRef := models.S3Reference{
 		Bucket: rawRef.Bucket,
 		Key:    fmt.Sprintf("%s/processing/layout-metadata.json", verificationID),
 	}
-	
+
 	// Create historical context reference for PREVIOUS_VS_CURRENT
 	historicalContextRef := models.S3Reference{
 		Bucket: rawRef.Bucket,
 		Key:    fmt.Sprintf("%s/processing/historical-context.json", verificationID),
 	}
-	
+
 	tree := S3ReferenceTree{
 		Initialization: initRef,
 		Images: ImageReferences{
@@ -116,12 +116,12 @@ func buildS3RefTree(
 			Turn1Processed: procRef,
 		},
 	}
-	
+
 	// Only include promptRef if the key is not empty
 	if promptRef.Key != "" {
 		tree.Prompts.Turn1Prompt = promptRef
 	}
-	
+
 	return tree
 }
 
@@ -129,25 +129,25 @@ func buildS3RefTree(
 func extractVerificationID(key string) string {
 	// Expected format: verif-YYYYMMDDHHMMSS/responses/turn1-raw-response.json
 	// or: YYYY/MM/DD/verif-YYYYMMDDHHMMSS/responses/turn1-raw-response.json
-	
+
 	parts := strings.Split(key, "/")
 	for _, part := range parts {
 		if strings.HasPrefix(part, "verif-") {
 			return part
 		}
 	}
-	
+
 	// If we can't find a verification ID, return a placeholder
 	return "unknown-verification-id"
 }
 
 // buildSummary creates a summary of the turn execution
 func buildSummary(
-	totalDurationMs int64, 
-	invoke *models.BedrockResponse, 
+	totalDurationMs int64,
+	invoke *models.BedrockResponse,
 	verificationType string,
 	bedrockLatencyMs int64,
-	dynamoOK *bool,
+	dynamoOK bool,
 ) ExecutionSummary {
 	// Convert TokenUsage to TokenUsageDetailed
 	tokenUsage := TokenUsageDetailed{
@@ -156,20 +156,17 @@ func buildSummary(
 		Thinking: invoke.TokenUsage.ThinkingTokens,
 		Total:    invoke.TokenUsage.TotalTokens,
 	}
-	
+
 	// Default to true for conversation tracked and S3 storage completed
 	// These could be parameterized in the future if needed
 	conversationTracked := true
 	s3StorageCompleted := true
-	
+
 	// Default to true for dynamoOK if not provided
-	dynamodbUpdated := true
-	if dynamoOK != nil {
-		dynamodbUpdated = *dynamoOK
-	}
-	
+	dynamodbUpdated := dynamoOK
+
 	// Use the provided bedrock latency
-	
+
 	return ExecutionSummary{
 		AnalysisStage:       "REFERENCE_ANALYSIS",
 		VerificationType:    verificationType,
@@ -188,7 +185,7 @@ func extractCheckingImageUrl(s3Key string) string {
 	if s3Key == "" {
 		return ""
 	}
-	
+
 	// In a real implementation, this would parse the S3 key to extract the URL
 	// For now, we'll just return the key as a placeholder
 	return s3Key
@@ -199,12 +196,12 @@ func calculateHoursSince(timestamp string) float64 {
 	if timestamp == "" {
 		return 0
 	}
-	
+
 	t, err := time.Parse(time.RFC3339, timestamp)
 	if err != nil {
 		return 0
 	}
-	
+
 	duration := time.Since(t)
 	return duration.Hours()
 }

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/response_builder.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/response_builder.go
@@ -27,9 +27,9 @@ func (r *ResponseBuilder) BuildCombinedTurnResponse(
 	stages []schema.ProcessingStage,
 	totalDurationMs int64,
 	bedrockLatencyMs int64,
-	dynamoOK *bool,
+	dynamoOK bool,
 ) *schema.CombinedTurnResponse {
-	
+
 	// Build base turn response
 	turnResponse := &schema.TurnResponse{
 		TurnId:    1,
@@ -92,11 +92,11 @@ func (r *ResponseBuilder) BuildStepFunctionResponse(
 	invoke *models.BedrockResponse,
 	totalDurationMs int64,
 	bedrockLatencyMs int64,
-	dynamoOK *bool,
+	dynamoOK bool,
 ) *models.StepFunctionResponse {
 	// Build S3 reference tree in the expected format
 	s3RefTree := buildS3RefTree(req.S3Refs, promptRef, rawRef, procRef)
-	
+
 	// Convert S3RefTree to map[string]interface{} for Step Functions
 	s3References := map[string]interface{}{
 		"initialization": s3RefTree.Initialization,
@@ -113,15 +113,15 @@ func (r *ResponseBuilder) BuildStepFunctionResponse(
 			"turn1Processed": procRef,
 		},
 	}
-	
+
 	// Build summary in the expected format
 	summary := buildSummary(totalDurationMs, invoke, req.VerificationContext.VerificationType, bedrockLatencyMs, dynamoOK)
-	
+
 	// Convert ExecutionSummary to map[string]interface{}
 	summaryMap := map[string]interface{}{
-		"analysisStage":       summary.AnalysisStage,
-		"verificationType":    summary.VerificationType,
-		"processingTimeMs":    summary.ProcessingTimeMs,
+		"analysisStage":    summary.AnalysisStage,
+		"verificationType": summary.VerificationType,
+		"processingTimeMs": summary.ProcessingTimeMs,
 		"tokenUsage": map[string]interface{}{
 			"input":    summary.TokenUsage.Input,
 			"output":   summary.TokenUsage.Output,
@@ -134,7 +134,7 @@ func (r *ResponseBuilder) BuildStepFunctionResponse(
 		"conversationTracked": summary.ConversationTracked,
 		"s3StorageCompleted":  summary.S3StorageCompleted,
 	}
-	
+
 	return &models.StepFunctionResponse{
 		VerificationID: req.VerificationID,
 		S3References:   s3References,

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/response_builder_test.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/response_builder_test.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"testing"
+
+	"workflow-function/ExecuteTurn1Combined/internal/config"
+	"workflow-function/ExecuteTurn1Combined/internal/models"
+	"workflow-function/shared/schema"
+)
+
+func TestBuildCombinedTurnResponseSetsDynamoFlag(t *testing.T) {
+	cfg := config.Config{}
+	cfg.AWS.BedrockModel = "test-model"
+	builder := NewResponseBuilder(cfg)
+
+	req := &models.Turn1Request{
+		VerificationID:      "verif1",
+		VerificationContext: models.VerificationContext{VerificationType: schema.VerificationTypeLayoutVsChecking},
+	}
+
+	invoke := &models.BedrockResponse{
+		Raw:        []byte("ok"),
+		RequestID:  "req",
+		TokenUsage: models.TokenUsage{InputTokens: 1, OutputTokens: 1, ThinkingTokens: 1, TotalTokens: 3},
+	}
+
+	resp := builder.BuildCombinedTurnResponse(
+		req,
+		"prompt",
+		models.S3Reference{},
+		models.S3Reference{},
+		models.S3Reference{},
+		invoke,
+		nil,
+		10,
+		5,
+		false,
+	)
+
+	summary := resp.ContextEnrichment["summary"].(ExecutionSummary)
+	if summary.DynamodbUpdated {
+		t.Errorf("expected dynamo flag false, got true")
+	}
+}


### PR DESCRIPTION
## Summary
- ensure DynamoManager returns whether writes succeeded
- pass that flag through handler to response builders
- surface `dynamodbUpdated` correctly in summaries
- add unit tests for DynamoManager and response builder
- document fix in CHANGELOG

## Testing
- `go vet ./...` *(fails: no network)*