### PR TITLE
Fix DynamoDB update keys

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the ExecuteTurn1Combined function will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.5] - 2025-05-30
+
+### Fixed
+- **DynamoDB Update Failures:**
+    - Added `verificationAt` sort key to `UpdateVerificationStatusEnhanced` so updates correctly target existing `VerificationResults` records. Requires passing the initial timestamp through `DynamoManager.Update`.
+    - Corrected `UpdateConversationTurn` query to use `verificationId` as the partition key for `ConversationHistory`.
+    - Corrected `updateExistingConversationHistory` and `CompleteConversation` to use `verificationId` in DynamoDB keys.
+
 ## [2.2.4] - 2025-05-29
 
 ### Fixed

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager.go
@@ -26,12 +26,13 @@ func NewDynamoManager(dynamo services.DynamoDBService, _ config.Config, log logg
 func (d *DynamoManager) Update(
 	ctx context.Context,
 	verificationID string,
+	initialVerificationAt string,
 	statusEntry schema.StatusHistoryEntry,
 	turnEntry *schema.TurnResponse,
 ) bool {
 	dynamoOK := true
 
-	if err := d.dynamo.UpdateVerificationStatusEnhanced(ctx, verificationID, statusEntry); err != nil {
+	if err := d.dynamo.UpdateVerificationStatusEnhanced(ctx, verificationID, initialVerificationAt, statusEntry); err != nil {
 		d.log.Warn("dynamodb status update failed", map[string]interface{}{
 			"error":     err.Error(),
 			"retryable": errors.IsRetryable(err),

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager_test.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager_test.go
@@ -23,7 +23,7 @@ func (m *mockDynamo) UpdateVerificationStatus(ctx context.Context, verificationI
 func (m *mockDynamo) RecordConversationTurn(ctx context.Context, turn *models.ConversationTurn) error {
 	return nil
 }
-func (m *mockDynamo) UpdateVerificationStatusEnhanced(ctx context.Context, verificationID string, entry schema.StatusHistoryEntry) error {
+func (m *mockDynamo) UpdateVerificationStatusEnhanced(ctx context.Context, verificationID string, initialVerificationAt string, entry schema.StatusHistoryEntry) error {
 	return m.statusErr
 }
 func (m *mockDynamo) RecordConversationHistory(ctx context.Context, ct *schema.ConversationTracker) error {
@@ -65,7 +65,7 @@ func (m *mockDynamo) GetLayoutMetadata(ctx context.Context, layoutID int, layout
 
 func TestDynamoManagerUpdateSuccess(t *testing.T) {
 	mgr := NewDynamoManager(&mockDynamo{}, config.Config{}, logger.New("test", "test"))
-	ok := mgr.Update(context.Background(), "id", schema.StatusHistoryEntry{}, &schema.TurnResponse{})
+	ok := mgr.Update(context.Background(), "id", "2025-05-30T00:00:00Z", schema.StatusHistoryEntry{}, &schema.TurnResponse{})
 	if !ok {
 		t.Errorf("expected true on success")
 	}
@@ -73,7 +73,7 @@ func TestDynamoManagerUpdateSuccess(t *testing.T) {
 
 func TestDynamoManagerUpdateFailure(t *testing.T) {
 	mgr := NewDynamoManager(&mockDynamo{statusErr: errors.New("fail")}, config.Config{}, logger.New("test", "test"))
-	ok := mgr.Update(context.Background(), "id", schema.StatusHistoryEntry{}, &schema.TurnResponse{})
+	ok := mgr.Update(context.Background(), "id", "2025-05-30T00:00:00Z", schema.StatusHistoryEntry{}, &schema.TurnResponse{})
 	if ok {
 		t.Errorf("expected false on failure")
 	}

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/event_transformer.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/event_transformer.go
@@ -251,6 +251,7 @@ func (e *EventTransformer) TransformStepFunctionEvent(ctx context.Context, event
 // convertSchemaToLocalVerificationContext converts shared schema to local model with comprehensive mapping
 func convertSchemaToLocalVerificationContext(schemaCtx schema.VerificationContext, layoutMetadata *schema.LayoutMetadata) models.VerificationContext {
 	localCtx := models.VerificationContext{
+		VerificationAt:    schemaCtx.VerificationAt,
 		VerificationType:  schemaCtx.VerificationType,
 		VendingMachineId:  schemaCtx.VendingMachineId,
 		LayoutId:          schemaCtx.LayoutId,

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/handler.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/handler.go
@@ -196,7 +196,7 @@ func (h *Handler) Handle(ctx context.Context, req *models.Turn1Request) (*schema
 	}
 
 	// Perform DynamoDB updates synchronously
-	dynamoOK := h.dynamoManager.Update(ctx, req.VerificationID, statusEntry, turnEntry)
+	dynamoOK := h.dynamoManager.Update(ctx, req.VerificationID, req.VerificationContext.VerificationAt, statusEntry, turnEntry)
 
 	// Final status update
 	h.updateStatus(ctx, req.VerificationID, schema.StatusTurn1Completed, "completion", map[string]interface{}{
@@ -349,7 +349,7 @@ func (h *Handler) HandleForStepFunction(ctx context.Context, req *models.Turn1Re
 		},
 	}
 
-	dynamoOK := h.dynamoManager.Update(ctx, req.VerificationID, statusEntry, turnEntry)
+	dynamoOK := h.dynamoManager.Update(ctx, req.VerificationID, req.VerificationContext.VerificationAt, statusEntry, turnEntry)
 
 	// Final status update
 	h.updateStatus(ctx, req.VerificationID, schema.StatusTurn1Completed, "completion", map[string]interface{}{

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/models/verification.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/models/verification.go
@@ -9,6 +9,8 @@ import (
 // VerificationContext carries metadata to drive prompt generation.
 // This is compatible with the schema package but maintains local structure
 type VerificationContext struct {
+	// Timestamp when the verification was first initialized
+	VerificationAt string `json:"verificationAt,omitempty"`
 	// Type of verification: e.g. "LAYOUT_VS_CHECKING" or "PREVIOUS_VS_CURRENT"
 	VerificationType string `json:"verificationType"`
 	// Arbitrary planogram/layout details for LAYOUT_VS_CHECKING


### PR DESCRIPTION
## Summary
- pass initial verification timestamp through dynamo manager
- include sort key when updating VerificationResults
- use correct attribute names for conversation history table
- extend VerificationContext with `VerificationAt`
- update tests
- document fixes

## Testing
- `go test ./...` *(fails: go: cannot load module product-approach/workflow-function/ExecuteTurn1 listed in go.work file: open product-approach/workflow-function/ExecuteTurn1/go.mod: no such file or directory)*