### PR TITLE
Fix conversation history key names

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Added `verificationAt` sort key to `UpdateVerificationStatusEnhanced` so updates correctly target existing `VerificationResults` records. Requires passing the initial timestamp through `DynamoManager.Update`.
     - Corrected `UpdateConversationTurn` query to use `verificationId` as the partition key for `ConversationHistory`.
     - Corrected `updateExistingConversationHistory` and `CompleteConversation` to use `verificationId` in DynamoDB keys.
+    - Modified `RecordConversationHistory` to construct items using `verificationId` as the partition key attribute.
+    - `CompleteConversation` now requires `conversationAt` (sort key) to correctly target existing records.
 
 ## [2.2.4] - 2025-05-29
 

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager_test.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager_test.go
@@ -53,7 +53,7 @@ func (m *mockDynamo) InitializeConversationHistory(ctx context.Context, verifica
 func (m *mockDynamo) UpdateConversationTurn(ctx context.Context, verificationID string, turnData *schema.TurnResponse) error {
 	return m.turnErr
 }
-func (m *mockDynamo) CompleteConversation(ctx context.Context, verificationID string, finalStatus string) error {
+func (m *mockDynamo) CompleteConversation(ctx context.Context, verificationID string, conversationAt string, finalStatus string) error {
 	return nil
 }
 func (m *mockDynamo) QueryPreviousVerification(ctx context.Context, checkingImageUrl string) (*schema.VerificationContext, error) {


### PR DESCRIPTION
## Summary
- correct the interface and logic to use verificationId and conversationAt keys for CompleteConversation
- rebuild RecordConversationHistory so it writes verificationId instead of conversationId
- update mock and changelog

## Testing
- `go test ./...` *(fails: cannot load module ../ExecuteTurn1)*