### PR TITLE
Refactor ExecuteTurn1Combined historical context loading

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the ExecuteTurn1Combined function will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.6] - 2025-05-31
+
+### Changed
+- **Historical Context Loading Refactor:**
+  - Historical context for `PREVIOUS_VS_CURRENT` verifications is now loaded from the provided S3 reference `processing_historical-context`.
+  - Removed direct DynamoDB queries for previous verification data in `HistoricalContextLoader`.
+  - `EventTransformer` now passes the historical context S3 reference through to the `Turn1Request` structure.
+  - `Turn1RequestS3Refs` updated to include `Processing` references.
+  - `NewHistoricalContextLoader` accepts an `S3StateManager` instance for S3 operations.
+
 ## [2.2.5] - 2025-05-30
 
 ### Fixed

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/event_transformer.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/event_transformer.go
@@ -221,7 +221,23 @@ func (e *EventTransformer) TransformStepFunctionEvent(ctx context.Context, event
 					Size:   metadata.ReferenceImage.StorageMetadata.StoredSize,
 				},
 			},
+			Processing: models.ProcessingReferences{},
 		},
+	}
+
+	// Populate historical context S3 reference for PREVIOUS_VS_CURRENT
+	if initData.VerificationContext.VerificationType == schema.VerificationTypePreviousVsCurrent {
+		if histCtxRef, ok := event.S3References["processing_historical-context"]; ok {
+			req.S3Refs.Processing.HistoricalContext = histCtxRef
+			transformLogger.Info("historical_context_s3_reference_found_in_event", map[string]interface{}{
+				"bucket": histCtxRef.Bucket,
+				"key":    histCtxRef.Key,
+			})
+		} else {
+			transformLogger.Warn("s3_reference_for_processing_historical_context_not_found_in_event_for_uc2", map[string]interface{}{
+				"verification_id": event.VerificationID,
+			})
+		}
 	}
 
 	// STRATEGIC STAGE 6: Comprehensive transformation completion with schema validation

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/handler.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/handler.go
@@ -60,7 +60,7 @@ func NewHandler(
 		eventTransformer: NewEventTransformer(s3Mgr, log),
 		promptGenerator:  NewPromptGenerator(promptGen, *cfg),
 		contextLoader:    NewContextLoader(s3Mgr, log),
-		historicalLoader: NewHistoricalContextLoader(dynamoClient, log),
+		historicalLoader: NewHistoricalContextLoader(s3Mgr, dynamoClient, log),
 		bedrockInvoker:   NewBedrockInvoker(bedrockClient, *cfg, log),
 		storageManager:   NewStorageManager(s3Mgr, *cfg, log),
 		dynamoManager:    NewDynamoManager(dynamoClient, *cfg, log),

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/historical_context_loader.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/historical_context_loader.go
@@ -2,8 +2,6 @@ package handler
 
 import (
 	"context"
-	"fmt"
-	"reflect"
 	"time"
 
 	"workflow-function/ExecuteTurn1Combined/internal/models"
@@ -15,13 +13,15 @@ import (
 // HistoricalContextLoader handles loading historical verification context
 type HistoricalContextLoader struct {
 	dynamo services.DynamoDBService
+	s3     services.S3StateManager
 	log    logger.Logger
 }
 
 // NewHistoricalContextLoader creates a new instance of HistoricalContextLoader
-func NewHistoricalContextLoader(dynamo services.DynamoDBService, log logger.Logger) *HistoricalContextLoader {
+func NewHistoricalContextLoader(s3 services.S3StateManager, dynamo services.DynamoDBService, log logger.Logger) *HistoricalContextLoader {
 	return &HistoricalContextLoader{
 		dynamo: dynamo,
+		s3:     s3,
 		log:    log,
 	}
 }
@@ -34,118 +34,43 @@ func (h *HistoricalContextLoader) LoadHistoricalContext(ctx context.Context, req
 
 	historicalStart := time.Now()
 
-	// Extract checking image URL from the reference image S3 key
-	checkingImageUrl := extractCheckingImageUrl(req.S3Refs.Images.ReferenceBase64.Key)
-
-	if checkingImageUrl == "" {
-		return time.Since(historicalStart), nil
-	}
-
-	contextLogger.Info("Loading historical verification context", map[string]interface{}{
-		"checking_image_url": checkingImageUrl,
-		"verification_type":  req.VerificationContext.VerificationType,
-	})
-
-	// Query for previous verification using the checking image URL
-	previousVerification, err := h.dynamo.QueryPreviousVerification(ctx, checkingImageUrl)
-	if err != nil {
-		// Log warning but continue - historical context is optional enhancement
-		contextLogger.Warn("Failed to load historical verification context", map[string]interface{}{
-			"error":              err.Error(),
-			"checking_image_url": checkingImageUrl,
+	if ref := req.S3Refs.Processing.HistoricalContext; ref.Key != "" {
+		contextLogger.Info("loading_historical_context_from_s3", map[string]interface{}{
+			"bucket": ref.Bucket,
+			"key":    ref.Key,
 		})
-		return time.Since(historicalStart), nil
-	}
 
-	if previousVerification == nil {
-		return time.Since(historicalStart), nil
-	}
-
-	// Populate historical context with previous verification data
-	req.VerificationContext.HistoricalContext = map[string]interface{}{
-		"PreviousVerificationAt":     previousVerification.VerificationAt,
-		"PreviousVerificationStatus": previousVerification.CurrentStatus,
-		"PreviousVerificationId":     previousVerification.VerificationId,
-		"HoursSinceLastVerification": calculateHoursSince(previousVerification.VerificationAt),
-	}
-
-	// Add layout information from the previous verification if present
-	if previousVerification.LayoutId > 0 {
-		req.VerificationContext.HistoricalContext["LayoutId"] = previousVerification.LayoutId
-	}
-	if previousVerification.LayoutPrefix != "" {
-		req.VerificationContext.HistoricalContext["LayoutPrefix"] = previousVerification.LayoutPrefix
-	}
-
-	var machineStructureFound bool
-
-	// Attempt to extract machine structure directly from previous verification via reflection
-	pvValue := reflect.ValueOf(previousVerification).Elem()
-	msField := pvValue.FieldByName("MachineStructure")
-	if msField.IsValid() {
-		if msMap, ok := msField.Interface().(map[string]interface{}); ok && msMap != nil {
-			if rc, ok := msMap["rowCount"].(float64); ok {
-				req.VerificationContext.HistoricalContext["RowCount"] = int(rc)
-				machineStructureFound = true
-			}
-			if cc, ok := msMap["columnCount"].(float64); ok {
-				req.VerificationContext.HistoricalContext["ColumnCount"] = int(cc)
-			}
-			if rl, ok := msMap["rowOrder"].([]interface{}); ok {
-				rowLabels := make([]string, len(rl))
-				for i, v := range rl {
-					rowLabels[i] = fmt.Sprintf("%v", v)
-				}
-				req.VerificationContext.HistoricalContext["RowLabels"] = rowLabels
-			}
-			if machineStructureFound {
-				contextLogger.Info("Populated historical machine structure from previous verification", nil)
-			}
+		var data map[string]interface{}
+		err := h.s3.LoadJSON(ctx, ref, &data)
+		if err != nil {
+			contextLogger.Warn("failed_to_load_historical_context_from_s3", map[string]interface{}{
+				"error": err.Error(),
+				"key":   ref.Key,
+			})
+			return time.Since(historicalStart), nil
 		}
-	}
 
-	// If not found directly, use layout metadata lookup
-	if !machineStructureFound && previousVerification.LayoutId > 0 && previousVerification.LayoutPrefix != "" {
-		contextLogger.Info("Attempting to load LayoutMetadata for historical context", map[string]interface{}{
-			"layoutId":     previousVerification.LayoutId,
-			"layoutPrefix": previousVerification.LayoutPrefix,
-		})
-		layoutMeta, err := h.dynamo.GetLayoutMetadata(ctx, previousVerification.LayoutId, previousVerification.LayoutPrefix)
-		if err == nil && layoutMeta != nil && layoutMeta.MachineStructure != nil {
-			if rc, ok := layoutMeta.MachineStructure["rowCount"].(float64); ok {
-				req.VerificationContext.HistoricalContext["RowCount"] = int(rc)
-				machineStructureFound = true
+		if data != nil {
+			if req.VerificationContext.HistoricalContext == nil {
+				req.VerificationContext.HistoricalContext = make(map[string]interface{})
 			}
-			if cc, ok := layoutMeta.MachineStructure["columnCount"].(float64); ok {
-				req.VerificationContext.HistoricalContext["ColumnCount"] = int(cc)
+			for k, v := range data {
+				req.VerificationContext.HistoricalContext[k] = v
 			}
-			if rl, ok := layoutMeta.MachineStructure["rowOrder"].([]interface{}); ok {
-				rowLabels := make([]string, len(rl))
-				for i, v := range rl {
-					rowLabels[i] = fmt.Sprintf("%v", v)
-				}
-				req.VerificationContext.HistoricalContext["RowLabels"] = rowLabels
+
+			if ts, ok := data["PreviousVerificationAt"].(string); ok {
+				req.VerificationContext.HistoricalContext["HoursSinceLastVerification"] = calculateHoursSince(ts)
 			}
-			if machineStructureFound {
-				contextLogger.Info("Successfully populated historical machine structure from LayoutMetadata", map[string]interface{}{"layoutId": layoutMeta.LayoutId})
-			}
-		} else if err != nil {
-			contextLogger.Warn("Failed to load LayoutMetadata for historical context", map[string]interface{}{
-				"error":        err.Error(),
-				"layoutId":     previousVerification.LayoutId,
-				"layoutPrefix": previousVerification.LayoutPrefix,
+
+			contextLogger.Info("historical_context_loaded_from_s3", map[string]interface{}{
+				"key": ref.Key,
 			})
 		}
+		return time.Since(historicalStart), nil
 	}
 
-	if !machineStructureFound {
-		contextLogger.Warn("Machine structure could not be determined for historical context", nil)
-	}
-
-	contextLogger.Info("Successfully loaded historical verification context", map[string]interface{}{
-		"previous_verification_id": previousVerification.VerificationId,
-		"previous_verification_at": previousVerification.VerificationAt,
-		"hours_since_last":         req.VerificationContext.HistoricalContext["HoursSinceLastVerification"],
+	contextLogger.Warn("historical_context_s3_reference_missing", map[string]interface{}{
+		"verification_id": req.VerificationID,
 	})
 
 	return time.Since(historicalStart), nil

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/models/request.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/models/request.go
@@ -10,8 +10,9 @@ type Turn1Request struct {
 
 // Turn1RequestS3Refs groups the S3 references needed for Turn-1.
 type Turn1RequestS3Refs struct {
-	Prompts PromptRefs `json:"prompts"`
-	Images  ImageRefs  `json:"images"`
+	Prompts    PromptRefs           `json:"prompts"`
+	Images     ImageRefs            `json:"images"`
+	Processing ProcessingReferences `json:"processing,omitempty"`
 }
 
 // PromptRefs holds S3 locations for prompt artifacts.
@@ -22,6 +23,12 @@ type PromptRefs struct {
 // ImageRefs holds S3 locations for image artifacts.
 type ImageRefs struct {
 	ReferenceBase64 S3Reference `json:"referenceBase64"` // reference-base64.json
+}
+
+// ProcessingReferences holds S3 locations for processing artifacts.
+type ProcessingReferences struct {
+	HistoricalContext S3Reference `json:"historicalContext,omitempty"`
+	LayoutMetadata    S3Reference `json:"layoutMetadata,omitempty"`
 }
 
 // Turn1ResponseS3Refs groups the S3 references created by Turn-1.


### PR DESCRIPTION
## Summary
- allow Turn1Request to hold processing S3 references
- pass through historical context S3 ref from StepFunction events
- load historical context from S3 instead of DynamoDB
- wire S3 service into HistoricalContextLoader
- document change in CHANGELOG

## Testing
- `make test` *(fails: cannot load modules referenced in go.work)*