### PR TITLE
Refactor Turn1 output handling to Markdown

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the ExecuteTurn1Combined function will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2025-05-25
+### Changed
+- **Refactor: Adopt "Markdown-Centric" Approach for Turn 1 Bedrock Response Processing (POC Simplification).**
+  - Simplified `internal/bedrockparser` to return cleaned Markdown via `ParseBedrockResponseAsMarkdown`.
+  - `StorageManager` now stores the Markdown output in `processing/turn1-processed-response.md` with `text/markdown` content type.
+  - DynamoDB `VerificationResults` records now reference this Markdown file using `processedTurn1MarkdownRef` instead of storing deeply parsed fields.
+  - Added `UpdateTurn1CompletionDetails` in DynamoDB service and updated handler logic accordingly.
+
 ## [2.3.0] - 2025-05-25
 ### Added
 - **New `internal/bedrockparser` package:** Introduced parser for Bedrock Turn 1 response.

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/bedrockparser/turn1_parser.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/bedrockparser/turn1_parser.go
@@ -1,112 +1,23 @@
 package bedrockparser
 
 import (
-	"fmt"
-	"regexp"
-	"strconv"
 	"strings"
-
-	"workflow-function/shared/schema"
 )
 
-// ParsedTurn1Data holds the structured results from parsing Bedrock's Turn 1 response.
-type ParsedTurn1Data struct {
-	InitialConfirmation string                  `json:"initialConfirmation"`
-	MachineStructure    schema.MachineStructure `json:"machineStructure"`
-	ReferenceRowStatus  map[string]string       `json:"referenceRowStatus"`
-	ReferenceSummary    string                  `json:"referenceSummary"`
+// ParsedTurn1Markdown holds the cleaned Markdown content from Bedrock's Turn 1 response.
+type ParsedTurn1Markdown struct {
+	AnalysisMarkdown string `json:"analysisMarkdown"`
 }
 
-// ParseTurn1Response parses the Markdown-like text from Bedrock's Turn 1 analysis
-// into a structured ParsedTurn1Data object.
-func ParseTurn1Response(text string) (*ParsedTurn1Data, error) {
-	if strings.TrimSpace(text) == "" {
-		return nil, nil
+// ParseBedrockResponseAsMarkdown extracts and cleans the Bedrock Turn 1 textual response.
+func ParseBedrockResponseAsMarkdown(bedrockTextResponse string) (*ParsedTurn1Markdown, error) {
+	if strings.TrimSpace(bedrockTextResponse) == "" {
+		// Return empty markdown struct for empty input
+		return &ParsedTurn1Markdown{AnalysisMarkdown: ""}, nil
 	}
 
-	result := &ParsedTurn1Data{
-		ReferenceRowStatus: make(map[string]string),
-	}
+	cleaned := strings.ReplaceAll(bedrockTextResponse, "\r\n", "\n")
+	cleaned = strings.TrimSpace(cleaned)
 
-	// Normalize line endings
-	text = strings.ReplaceAll(text, "\r\n", "\n")
-
-	// Extract Initial Confirmation section
-	reInit := regexp.MustCompile(`(?s)\*\*INITIAL CONFIRMATION:\*\*\s*(.*?)\n\s*\*\*ROW STATUS ANALYSIS`)
-	if matches := reInit.FindStringSubmatch(text); len(matches) > 1 {
-		section := strings.TrimSpace(matches[1])
-		result.InitialConfirmation = section
-
-		// Parse machine structure details from the confirmation text
-		// Example sentences:
-		// "Successfully identified 6 physical rows (A-Top to F-Bottom)."
-		// "Successfully identified 7 slots per row (01-Left to 07-Right)."
-		rowRe := regexp.MustCompile(`(?i)(\d+)\s+physical\s+rows\s*\((\w)-Top\s+to\s+(\w)-Bottom\)`)
-		colRe := regexp.MustCompile(`(?i)(\d+)\s+slots\s+per\s+row\s*\(01-Left\s+to\s+(\d+)\-Right\)`)
-		if rm := rowRe.FindStringSubmatch(section); len(rm) == 4 {
-			rowCount := rm[1]
-			startRow := rm[2]
-			endRow := rm[3]
-			if n, err := strconv.Atoi(rowCount); err == nil {
-				result.MachineStructure.RowCount = n
-				result.MachineStructure.RowOrder = buildRowOrder(startRow, endRow)
-			}
-		}
-		if cm := colRe.FindStringSubmatch(section); len(cm) == 3 {
-			colCount := cm[1]
-			endCol := cm[2]
-			if n, err := strconv.Atoi(colCount); err == nil {
-				result.MachineStructure.ColumnsPerRow = n
-				result.MachineStructure.ColumnOrder = buildColumnOrder(n, endCol)
-			}
-		}
-	}
-
-	// Extract Reference Row Status section
-	reRows := regexp.MustCompile(`(?s)\*\*ROW STATUS ANALYSIS \(Reference Image\):\*\*\n(.*?)\n\s*\*\*REFERENCE IMAGE SUMMARY`)
-	if matches := reRows.FindStringSubmatch(text); len(matches) > 1 {
-		rowsBlock := strings.TrimSpace(matches[1])
-		lines := strings.Split(rowsBlock, "\n")
-		rowRe := regexp.MustCompile(`\*\s*\*\*Row\s+(\w+)\s*(?:\(.*?\))?:\*\*\s*(.*)`)
-		for _, l := range lines {
-			l = strings.TrimSpace(l)
-			if l == "" {
-				continue
-			}
-			if rm := rowRe.FindStringSubmatch(l); len(rm) == 3 {
-				rowLabel := rm[1]
-				desc := strings.TrimSpace(rm[2])
-				result.ReferenceRowStatus[rowLabel] = desc
-			}
-		}
-	}
-
-	// Extract Reference Image Summary
-	reSummary := regexp.MustCompile(`(?s)\*\*REFERENCE IMAGE SUMMARY:\*\*\s*(.*?)\n\s*(?:\*\*|$)`)
-	if matches := reSummary.FindStringSubmatch(text); len(matches) > 1 {
-		result.ReferenceSummary = strings.TrimSpace(matches[1])
-	}
-
-	return result, nil
-}
-
-func buildRowOrder(start, end string) []string {
-	startRune := []rune(start)[0]
-	endRune := []rune(end)[0]
-	if endRune < startRune {
-		return nil
-	}
-	var rows []string
-	for r := startRune; r <= endRune; r++ {
-		rows = append(rows, string(r))
-	}
-	return rows
-}
-
-func buildColumnOrder(count int, endCol string) []string {
-	var cols []string
-	for i := 1; i <= count; i++ {
-		cols = append(cols, fmt.Sprintf("%02d", i))
-	}
-	return cols
+	return &ParsedTurn1Markdown{AnalysisMarkdown: cleaned}, nil
 }

--- a/product-approach/workflow-function/shared/schema/core.go
+++ b/product-approach/workflow-function/shared/schema/core.go
@@ -24,7 +24,7 @@ type VerificationContext struct {
 	ResourceValidation     *ResourceValidation `json:"resourceValidation,omitempty"`
 	NotificationEnabled    bool                `json:"notificationEnabled"`
 	Error                  *ErrorInfo          `json:"error,omitempty"`
-	
+
 	// Enhanced fields for combined function operations
 	CurrentStatus     string               `json:"currentStatus,omitempty"`
 	LastUpdatedAt     string               `json:"lastUpdatedAt,omitempty"`
@@ -77,7 +77,7 @@ type ResourceValidation struct {
 // S3StorageConfig contains configuration for S3 Base64 storage
 type S3StorageConfig struct {
 	TempBase64Bucket       string `json:"tempBase64Bucket"`
-	Base64RetrievalTimeout int    `json:"base64RetrievalTimeout"` // in milliseconds
+	Base64RetrievalTimeout int    `json:"base64RetrievalTimeout"`      // in milliseconds
 	StateBucketPrefix      string `json:"stateBucketPrefix,omitempty"` // for date-based path structure
 }
 
@@ -98,13 +98,13 @@ type ConversationState struct {
 
 // FinalResults represents the final verification results
 type FinalResults struct {
-	VerificationStatus string                  `json:"verificationStatus"`
-	ConfidenceScore    float64                 `json:"confidenceScore"`
-	DiscrepanciesCount int                     `json:"discrepanciesCount"`
-	Discrepancies      []Discrepancy           `json:"discrepancies,omitempty"`
-	ResultImageUrl     string                  `json:"resultImageUrl,omitempty"`
-	Summary            string                  `json:"summary,omitempty"`
-	ComparisonDetails  map[string]interface{}  `json:"comparisonDetails,omitempty"`
+	VerificationStatus string                 `json:"verificationStatus"`
+	ConfidenceScore    float64                `json:"confidenceScore"`
+	DiscrepanciesCount int                    `json:"discrepanciesCount"`
+	Discrepancies      []Discrepancy          `json:"discrepancies,omitempty"`
+	ResultImageUrl     string                 `json:"resultImageUrl,omitempty"`
+	Summary            string                 `json:"summary,omitempty"`
+	ComparisonDetails  map[string]interface{} `json:"comparisonDetails,omitempty"`
 }
 
 // Discrepancy represents a single discrepancy found during verification
@@ -179,119 +179,120 @@ type LayoutKey struct {
 
 // StatusHistoryEntry represents a single status transition
 type StatusHistoryEntry struct {
-    Status           string                 `json:"status"`
-    Timestamp        string                 `json:"timestamp"`
-    FunctionName     string                 `json:"functionName"`
-    ProcessingTimeMs int64                  `json:"processingTimeMs"`
-    Stage            string                 `json:"stage"`
-    Metrics          map[string]interface{} `json:"metrics,omitempty"`
+	Status           string                 `json:"status"`
+	Timestamp        string                 `json:"timestamp"`
+	FunctionName     string                 `json:"functionName"`
+	ProcessingTimeMs int64                  `json:"processingTimeMs"`
+	Stage            string                 `json:"stage"`
+	Metrics          map[string]interface{} `json:"metrics,omitempty"`
 }
 
 // ProcessingMetrics tracks performance across turns
 type ProcessingMetrics struct {
-    WorkflowTotal *WorkflowMetrics `json:"workflowTotal,omitempty"`
-    Turn1         *TurnMetrics     `json:"turn1,omitempty"`
-    Turn2         *TurnMetrics     `json:"turn2,omitempty"`
+	WorkflowTotal *WorkflowMetrics `json:"workflowTotal,omitempty"`
+	Turn1         *TurnMetrics     `json:"turn1,omitempty"`
+	Turn2         *TurnMetrics     `json:"turn2,omitempty"`
 }
 
 // WorkflowMetrics represents overall workflow performance
 type WorkflowMetrics struct {
-    StartTime     string `json:"startTime"`
-    EndTime       string `json:"endTime"`
-    TotalTimeMs   int64  `json:"totalTimeMs"`
-    FunctionCount int    `json:"functionCount"`
+	StartTime     string `json:"startTime"`
+	EndTime       string `json:"endTime"`
+	TotalTimeMs   int64  `json:"totalTimeMs"`
+	FunctionCount int    `json:"functionCount"`
 }
 
 // TurnMetrics represents individual turn performance
 type TurnMetrics struct {
-    StartTime          string      `json:"startTime"`
-    EndTime            string      `json:"endTime"`
-    TotalTimeMs        int64       `json:"totalTimeMs"`
-    BedrockLatencyMs   int64       `json:"bedrockLatencyMs"`
-    ProcessingTimeMs   int64       `json:"processingTimeMs"`
-    RetryAttempts      int         `json:"retryAttempts"`
-    TokenUsage         *TokenUsage `json:"tokenUsage,omitempty"`
+	StartTime        string      `json:"startTime"`
+	EndTime          string      `json:"endTime"`
+	TotalTimeMs      int64       `json:"totalTimeMs"`
+	BedrockLatencyMs int64       `json:"bedrockLatencyMs"`
+	ProcessingTimeMs int64       `json:"processingTimeMs"`
+	RetryAttempts    int         `json:"retryAttempts"`
+	TokenUsage       *TokenUsage `json:"tokenUsage,omitempty"`
 }
 
 // ErrorTracking manages error state throughout workflow
 type ErrorTracking struct {
-    HasErrors        bool        `json:"hasErrors"`
-    CurrentError     *ErrorInfo  `json:"currentError"`
-    ErrorHistory     []ErrorInfo `json:"errorHistory"`
-    RecoveryAttempts int         `json:"recoveryAttempts"`
-    LastErrorAt      string      `json:"lastErrorAt"`
+	HasErrors        bool        `json:"hasErrors"`
+	CurrentError     *ErrorInfo  `json:"currentError"`
+	ErrorHistory     []ErrorInfo `json:"errorHistory"`
+	RecoveryAttempts int         `json:"recoveryAttempts"`
+	LastErrorAt      string      `json:"lastErrorAt"`
 }
 
 // Enhanced VerificationContext now includes fields for combined function operations:
 // - CurrentStatus: Current processing status
-// - LastUpdatedAt: Last update timestamp  
+// - LastUpdatedAt: Last update timestamp
 // - StatusHistory: Complete status transition history
 // - ProcessingMetrics: Performance metrics tracking
 // - ErrorTracking: Error state management
 
 // ADD: Complete DynamoDB table structures
 type ConversationHistory struct {
-    VerificationId   string        `json:"verificationId" dynamodbav:"verificationId"`
-    ConversationAt   string        `json:"conversationAt" dynamodbav:"conversationAt"`
-    VendingMachineId string        `json:"vendingMachineId" dynamodbav:"vendingMachineId"`
-    LayoutId         int           `json:"layoutId" dynamodbav:"layoutId"`
-    LayoutPrefix     string        `json:"layoutPrefix" dynamodbav:"layoutPrefix"`
-    CurrentTurn      int           `json:"currentTurn" dynamodbav:"currentTurn"`
-    MaxTurns         int           `json:"maxTurns" dynamodbav:"maxTurns"`
-    TurnStatus       string        `json:"turnStatus" dynamodbav:"turnStatus"`
-    History          []TurnHistory `json:"history" dynamodbav:"history"`
-    ExpiresAt        int64         `json:"expiresAt,omitempty" dynamodbav:"expiresAt,omitempty"`
-    Metadata         map[string]interface{} `json:"metadata" dynamodbav:"metadata"`
+	VerificationId   string                 `json:"verificationId" dynamodbav:"verificationId"`
+	ConversationAt   string                 `json:"conversationAt" dynamodbav:"conversationAt"`
+	VendingMachineId string                 `json:"vendingMachineId" dynamodbav:"vendingMachineId"`
+	LayoutId         int                    `json:"layoutId" dynamodbav:"layoutId"`
+	LayoutPrefix     string                 `json:"layoutPrefix" dynamodbav:"layoutPrefix"`
+	CurrentTurn      int                    `json:"currentTurn" dynamodbav:"currentTurn"`
+	MaxTurns         int                    `json:"maxTurns" dynamodbav:"maxTurns"`
+	TurnStatus       string                 `json:"turnStatus" dynamodbav:"turnStatus"`
+	History          []TurnHistory          `json:"history" dynamodbav:"history"`
+	ExpiresAt        int64                  `json:"expiresAt,omitempty" dynamodbav:"expiresAt,omitempty"`
+	Metadata         map[string]interface{} `json:"metadata" dynamodbav:"metadata"`
 }
 
 type VerificationResults struct {
-    VerificationId         string                 `json:"verificationId" dynamodbav:"verificationId"`
-    VerificationAt         string                 `json:"verificationAt" dynamodbav:"verificationAt"`
-    VerificationType       string                 `json:"verificationType" dynamodbav:"verificationType"`
-    PreviousVerificationId string                 `json:"previousVerificationId,omitempty" dynamodbav:"previousVerificationId"`
-    LayoutId               int                    `json:"layoutId,omitempty" dynamodbav:"layoutId"`
-    LayoutPrefix           string                 `json:"layoutPrefix,omitempty" dynamodbav:"layoutPrefix"`
-    VendingMachineId       string                 `json:"vendingMachineId" dynamodbav:"vendingMachineId"`
-    Location               string                 `json:"location" dynamodbav:"location"`
-    ReferenceImageUrl      string                 `json:"referenceImageUrl" dynamodbav:"referenceImageUrl"`
-    CheckingImageUrl       string                 `json:"checkingImageUrl" dynamodbav:"checkingImageUrl"`
-    VerificationStatus     string                 `json:"verificationStatus" dynamodbav:"verificationStatus"`
-    MachineStructure       map[string]interface{} `json:"machineStructure" dynamodbav:"machineStructure"`
-    InitialConfirmation    string                 `json:"initialConfirmation" dynamodbav:"initialConfirmation"`
-    CorrectedRows          []string               `json:"correctedRows" dynamodbav:"correctedRows"`
-    EmptySlotReport        map[string]interface{} `json:"emptySlotReport" dynamodbav:"emptySlotReport"`
-    ReferenceStatus        map[string]string      `json:"referenceStatus" dynamodbav:"referenceStatus"`
-    CheckingStatus         map[string]string      `json:"checkingStatus" dynamodbav:"checkingStatus"`
-    Discrepancies          []Discrepancy          `json:"discrepancies" dynamodbav:"discrepancies"`
-    VerificationSummary    map[string]interface{} `json:"verificationSummary" dynamodbav:"verificationSummary"`
-    Metadata               map[string]interface{} `json:"metadata" dynamodbav:"metadata"`
+	VerificationId            string                 `json:"verificationId" dynamodbav:"verificationId"`
+	VerificationAt            string                 `json:"verificationAt" dynamodbav:"verificationAt"`
+	VerificationType          string                 `json:"verificationType" dynamodbav:"verificationType"`
+	PreviousVerificationId    string                 `json:"previousVerificationId,omitempty" dynamodbav:"previousVerificationId"`
+	LayoutId                  int                    `json:"layoutId,omitempty" dynamodbav:"layoutId"`
+	LayoutPrefix              string                 `json:"layoutPrefix,omitempty" dynamodbav:"layoutPrefix"`
+	VendingMachineId          string                 `json:"vendingMachineId" dynamodbav:"vendingMachineId"`
+	Location                  string                 `json:"location" dynamodbav:"location"`
+	ReferenceImageUrl         string                 `json:"referenceImageUrl" dynamodbav:"referenceImageUrl"`
+	CheckingImageUrl          string                 `json:"checkingImageUrl" dynamodbav:"checkingImageUrl"`
+	VerificationStatus        string                 `json:"verificationStatus" dynamodbav:"verificationStatus"`
+	MachineStructure          map[string]interface{} `json:"machineStructure" dynamodbav:"machineStructure"`
+	InitialConfirmation       string                 `json:"initialConfirmation" dynamodbav:"initialConfirmation"`
+	ProcessedTurn1MarkdownRef S3Reference            `json:"processedTurn1MarkdownRef,omitempty" dynamodbav:"processedTurn1MarkdownRef,omitempty"`
+	CorrectedRows             []string               `json:"correctedRows" dynamodbav:"correctedRows"`
+	EmptySlotReport           map[string]interface{} `json:"emptySlotReport" dynamodbav:"emptySlotReport"`
+	ReferenceStatus           map[string]string      `json:"referenceStatus" dynamodbav:"referenceStatus"`
+	CheckingStatus            map[string]string      `json:"checkingStatus" dynamodbav:"checkingStatus"`
+	Discrepancies             []Discrepancy          `json:"discrepancies" dynamodbav:"discrepancies"`
+	VerificationSummary       map[string]interface{} `json:"verificationSummary" dynamodbav:"verificationSummary"`
+	Metadata                  map[string]interface{} `json:"metadata" dynamodbav:"metadata"`
 }
 
 // ADD: Notification support
 type NotificationConfig struct {
-    Enabled     bool              `json:"enabled"`
-    Channels    []string          `json:"channels"` // ["email", "sns", "webhook"]
-    Recipients  []string          `json:"recipients"`
-    Templates   map[string]string `json:"templates"`
-    Settings    map[string]interface{} `json:"settings"`
+	Enabled    bool                   `json:"enabled"`
+	Channels   []string               `json:"channels"` // ["email", "sns", "webhook"]
+	Recipients []string               `json:"recipients"`
+	Templates  map[string]string      `json:"templates"`
+	Settings   map[string]interface{} `json:"settings"`
 }
 
 type NotificationResult struct {
-    Channel     string `json:"channel"`
-    Status      string `json:"status"`
-    MessageId   string `json:"messageId,omitempty"`
-    Error       string `json:"error,omitempty"`
-    Timestamp   string `json:"timestamp"`
-    Attempts    int    `json:"attempts"`
+	Channel   string `json:"channel"`
+	Status    string `json:"status"`
+	MessageId string `json:"messageId,omitempty"`
+	Error     string `json:"error,omitempty"`
+	Timestamp string `json:"timestamp"`
+	Attempts  int    `json:"attempts"`
 }
 
 // ADD: Enhanced error handling
 type WorkflowError struct {
-    Stage       string                 `json:"stage"`
-    Function    string                 `json:"function"`
-    ErrorType   string                 `json:"errorType"`
-    Recoverable bool                   `json:"recoverable"`
-    RetryCount  int                    `json:"retryCount"`
-    Context     map[string]interface{} `json:"context,omitempty"`
-    Timestamp   string                 `json:"timestamp"`
+	Stage       string                 `json:"stage"`
+	Function    string                 `json:"function"`
+	ErrorType   string                 `json:"errorType"`
+	Recoverable bool                   `json:"recoverable"`
+	RetryCount  int                    `json:"retryCount"`
+	Context     map[string]interface{} `json:"context,omitempty"`
+	Timestamp   string                 `json:"timestamp"`
 }

--- a/product-approach/workflow-function/shared/schema/s3_reference.go
+++ b/product-approach/workflow-function/shared/schema/s3_reference.go
@@ -1,0 +1,8 @@
+package schema
+
+// S3Reference represents a pointer to an object in S3.
+type S3Reference struct {
+	Bucket string `json:"bucket" dynamodbav:"bucket"`
+	Key    string `json:"key" dynamodbav:"key"`
+	Size   int64  `json:"size,omitempty" dynamodbav:"size,omitempty"`
+}


### PR DESCRIPTION
## Summary
- simplify Turn1 parser to output markdown only
- store processed markdown `turn1-processed-response.md`
- add S3 method for custom content type
- update DynamoDB writes with markdown reference
- update handler and storage logic
- add `processedTurn1MarkdownRef` to schema

## Testing
- `go vet ./...` *(fails: cannot load modules referenced in go.work)*