### PR TITLE
Fix UTF-8 metadata for processed markdown

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to the ExecuteTurn1Combined function will be documented in t
 - Restored `ParsedTurn1Data` type to resolve compilation errors.
 - Removed redundant `nil` check when updating metrics in DynamoDB service.
 
+## [2.4.3] - 2025-05-27
+### Fixed
+- **Vietnamese Character Encoding:** Ensured UTF-8 preservation when storing the processed Turn 1 Markdown in S3. The `turn1-processed-response.md` object now sets `ContentType` to `text/markdown; charset=utf-8` for proper Unicode display.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/s3.go
@@ -784,7 +784,7 @@ func (m *s3Manager) StoreProcessedTurn1Markdown(ctx context.Context, verificatio
 
 	key := "processing/turn1-processed-response.md"
 	dataBytes := []byte(markdownContent)
-	stateRef, err := m.stateManager.StoreWithContentType(m.datePath(verificationID), key, dataBytes, "text/markdown")
+	stateRef, err := m.stateManager.StoreWithContentType(m.datePath(verificationID), key, dataBytes, "text/markdown; charset=utf-8")
 	if err != nil {
 		return models.S3Reference{}, errors.WrapError(err, errors.ErrorTypeS3,
 			"failed to store processed turn1 markdown", true).


### PR DESCRIPTION
## Summary
- ensure UTF-8 content type when storing processed Markdown
- document the fix for Vietnamese character encoding

## Testing
- `go test ./...` *(fails: cannot load module ../ExecuteTurn1 listed in go.work file)*