### PR TITLE
Refactor Step Function output S3 references

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -16,6 +16,18 @@ All notable changes to the ExecuteTurn1Combined function will be documented in t
 - Layout dimensions (`RowCount`, `ColumnCount`) are now loaded from layout metadata instead of using hard-coded defaults.
 - Simplified `VerificationContext.Validate` to only check for presence of `LayoutMetadata` or `HistoricalContext` as required.
 
+## [2.4.5] - 2025-06-01
+### Changed
+- Modified the structure of the `s3References` field in the Step Function output
+  to align with downstream expectations.
+  - `initialization` renamed to `processing_initialization`.
+  - `images.metadata` flattened to `images_metadata`.
+  - `processing.layoutMetadata` flattened to `processing_layout-metadata`.
+  - `processing.historicalContext` now outputs as `processing_historical-context`
+    only when `verificationType` is `PREVIOUS_VS_CURRENT`.
+- Ensured all generated S3 reference keys include the date-partition prefix so
+  paths are consistent across artifacts.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/response_builder.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/response_builder.go
@@ -99,19 +99,23 @@ func (r *ResponseBuilder) BuildStepFunctionResponse(
 
 	// Convert S3RefTree to map[string]interface{} for Step Functions
 	s3References := map[string]interface{}{
-		"initialization": s3RefTree.Initialization,
-		"images": map[string]interface{}{
-			"metadata": s3RefTree.Images.Metadata,
-		},
-		"processing": map[string]interface{}{
-			"historicalContext": s3RefTree.Processing.HistoricalContext,
-			"layoutMetadata":    s3RefTree.Processing.LayoutMetadata,
-		},
-		"prompts_system": s3RefTree.Prompts.SystemPrompt,
+		"processing_initialization": s3RefTree.Initialization,
+		"images_metadata":           s3RefTree.Images.Metadata,
+		"prompts_system":            s3RefTree.Prompts.SystemPrompt,
 		"responses": map[string]interface{}{
 			"turn1Raw":       rawRef,
 			"turn1Processed": procRef,
 		},
+	}
+
+	if s3RefTree.Processing.LayoutMetadata.Key != "" {
+		s3References["processing_layout-metadata"] = s3RefTree.Processing.LayoutMetadata
+	}
+
+	if req.VerificationContext.VerificationType == schema.VerificationTypePreviousVsCurrent {
+		if s3RefTree.Processing.HistoricalContext.Key != "" {
+			s3References["processing_historical-context"] = s3RefTree.Processing.HistoricalContext
+		}
 	}
 
 	// Build summary in the expected format


### PR DESCRIPTION
## Summary
- prefix initialization and metadata references with date partition
- expose helper to parse date partition from S3 keys
- flatten s3References map for step function output and rename fields
- conditionally output historical context reference
- document changes in CHANGELOG

## Testing
- `go test ./...` *(fails: cannot load modules)*