### PR TITLE
Fix S3 path for processed Markdown

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the ExecuteTurn1Combined function will be documented in this file.
 
+## [2.4.6] - 2025-06-02
+### Fixed
+- Corrected the S3 path for the processed Turn 1 Markdown response. The file is now stored under the `response/` directory instead of `processing/`.
+
 ## [2.4.2] - 2025-05-26
 ### Fixed
 - Restored `ParsedTurn1Data` type to resolve compilation errors.

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/s3.go
@@ -782,14 +782,14 @@ func (m *s3Manager) StoreProcessedTurn1Markdown(ctx context.Context, verificatio
 			map[string]interface{}{"verification_id": verificationID})
 	}
 
-	key := "processing/turn1-processed-response.md"
+	key := "response/turn1-processed-response.md"
 	dataBytes := []byte(markdownContent)
 	stateRef, err := m.stateManager.StoreWithContentType(m.datePath(verificationID), key, dataBytes, "text/markdown; charset=utf-8")
 	if err != nil {
 		return models.S3Reference{}, errors.WrapError(err, errors.ErrorTypeS3,
 			"failed to store processed turn1 markdown", true).
 			WithContext("verification_id", verificationID).
-			WithContext("category", "processing")
+			WithContext("category", "response")
 	}
 
 	return m.fromStateReference(stateRef), nil


### PR DESCRIPTION
## Summary
- store processed Turn1 Markdown under `response/` prefix
- log the correct category when storing the Markdown
- document the change in the changelog

## Testing
- `go test ./...` *(fails: module paths in go.work not present)*