### PR TITLE
Add ExecuteTurn2Combined skeleton

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to the ExecuteTurn2Combined function will be documented in this file.
+
+## [0.1.0] - 2025-06-04
+### Added
+- Initial skeleton implementation.

--- a/product-approach/workflow-function/ExecuteTurn2Combined/Dockerfile
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/Dockerfile
@@ -1,0 +1,8 @@
+FROM public.ecr.aws/docker/library/golang:1.24 as builder
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 go build -o /tmp/main ./cmd/main.go
+
+FROM public.ecr.aws/docker/library/alpine:3.18
+COPY --from=builder /tmp/main /var/task/main
+CMD ["/var/task/main"]

--- a/product-approach/workflow-function/ExecuteTurn2Combined/README.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/README.md
@@ -1,0 +1,5 @@
+# ExecuteTurn2Combined
+
+This Lambda function represents the second phase of the vending machine verification workflow. It loads the checking image, applies a prompt that references the analysis from Turn 1, invokes the LLM via Bedrock and stores the results in S3 and DynamoDB.
+
+This directory only provides a skeleton implementation to outline the intended structure. The real implementation should mirror the architecture of `ExecuteTurn1Combined` and make use of the shared packages in `workflow-function/shared`.

--- a/product-approach/workflow-function/ExecuteTurn2Combined/cmd/main.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/cmd/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/lambda"
+
+	internalConfig "workflow-function/ExecuteTurn2Combined/internal/config"
+	"workflow-function/ExecuteTurn2Combined/internal/handler"
+	"workflow-function/ExecuteTurn2Combined/internal/services"
+	"workflow-function/shared/errors"
+	"workflow-function/shared/logger"
+)
+
+// Application container wires dependencies for the Lambda
+type applicationContainer struct {
+	cfg *internalConfig.Config
+	log logger.Logger
+	hnd *handler.Handler
+}
+
+var containerInstance *applicationContainer
+
+func init() {
+	cfg, err := internalConfig.LoadConfiguration()
+	if err != nil {
+		if wfErr, ok := err.(*errors.WorkflowError); ok {
+			out, _ := json.Marshal(wfErr)
+			fmt.Fprintf(os.Stderr, "%s\n", out)
+		}
+		log.Fatalf("configuration error: %v", err)
+	}
+
+	logr := logger.New("ExecuteTurn2Combined", "main")
+
+	// Initialize services
+	s3Mgr, err := services.NewS3StateManager(*cfg, logr)
+	if err != nil {
+		log.Fatalf("failed to init s3 manager: %v", err)
+	}
+
+	bedrockSvc := services.NewBedrockService(logr)
+	dynamoSvc, err := services.NewDynamoDBService(cfg)
+	if err != nil {
+		log.Fatalf("failed to init dynamodb service: %v", err)
+	}
+
+	promptSvc, err := services.NewPromptService(cfg, logr)
+	if err != nil {
+		log.Fatalf("failed to init prompt service: %v", err)
+	}
+
+	h, err := handler.NewHandler(s3Mgr, bedrockSvc, dynamoSvc, promptSvc, logr, cfg)
+	if err != nil {
+		log.Fatalf("failed to init handler: %v", err)
+	}
+
+	containerInstance = &applicationContainer{cfg: cfg, log: logr, hnd: h}
+}
+
+func main() {
+	lambda.Start(func(ctx context.Context, event json.RawMessage) (*handler.StepFunctionResponse, error) {
+		var req handler.Turn2Request
+		if err := json.Unmarshal(event, &req); err != nil {
+			return nil, errors.NewInternalError("json_parse", err)
+		}
+		return containerInstance.hnd.Handle(ctx, &req)
+	})
+}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/go.mod
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/go.mod
@@ -1,0 +1,26 @@
+module workflow-function/ExecuteTurn2Combined
+
+go 1.24.0
+
+require (
+    github.com/aws/aws-lambda-go v1.48.0
+    github.com/aws/aws-sdk-go-v2 v1.36.3
+    github.com/aws/aws-sdk-go-v2/config v1.29.14
+    github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.19.0
+    github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1
+    workflow-function/shared/bedrock v0.0.0-00010101000000-000000000000
+    workflow-function/shared/errors v0.0.0
+    workflow-function/shared/logger v0.0.0
+    workflow-function/shared/s3state v0.0.0-00010101000000-000000000000
+    workflow-function/shared/schema v0.0.0-00010101000000-000000000000
+    workflow-function/shared/templateloader v0.0.0-00010101000000-000000000000
+)
+
+require github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.7.82
+
+replace workflow-function/shared/bedrock => ../shared/bedrock
+replace workflow-function/shared/errors => ../shared/errors
+replace workflow-function/shared/logger => ../shared/logger
+replace workflow-function/shared/s3state => ../shared/s3state
+replace workflow-function/shared/schema => ../shared/schema
+replace workflow-function/shared/templateloader => ../shared/templateloader

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrockparser/parser.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrockparser/parser.go
@@ -1,0 +1,3 @@
+package bedrockparser
+
+func ParseTurn2Response(data string) (interface{}, error) { return data, nil }

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+    "os"
+    "strconv"
+
+    "workflow-function/shared/errors"
+)
+
+// Config holds environment configuration for ExecuteTurn2Combined
+type Config struct {
+    AWS struct {
+        Region                    string
+        S3Bucket                  string
+        BedrockModel              string
+        AnthropicVersion          string
+        DynamoDBVerificationTable string
+        DynamoDBConversationTable string
+    }
+    Processing struct {
+        MaxTokens                int
+        BudgetTokens             int
+        ThinkingType             string
+        MaxRetries               int
+        BedrockConnectTimeoutSec int
+        BedrockCallTimeoutSec    int
+    }
+    Logging struct {
+        Level  string
+        Format string
+    }
+    Prompts struct {
+        TemplateVersion  string
+        TemplateBasePath string
+    }
+    DatePartitionTimezone string
+}
+
+// LoadConfiguration reads environment variables into Config
+func LoadConfiguration() (*Config, error) {
+    cfg := &Config{}
+    cfg.AWS.Region = getEnv("AWS_REGION", "us-east-1")
+    var err error
+    if cfg.AWS.S3Bucket, err = mustGet("STATE_BUCKET"); err != nil {
+        return nil, err
+    }
+    if cfg.AWS.BedrockModel, err = mustGet("BEDROCK_MODEL"); err != nil {
+        return nil, err
+    }
+    cfg.AWS.AnthropicVersion = getEnv("ANTHROPIC_VERSION", "bedrock-2023-05-31")
+    if cfg.AWS.DynamoDBVerificationTable, err = mustGet("DYNAMODB_VERIFICATION_TABLE"); err != nil {
+        return nil, err
+    }
+    if cfg.AWS.DynamoDBConversationTable, err = mustGet("DYNAMODB_CONVERSATION_TABLE"); err != nil {
+        return nil, err
+    }
+    cfg.Processing.MaxTokens = getInt("MAX_TOKENS", 24000)
+    cfg.Processing.BudgetTokens = getInt("BUDGET_TOKENS", 16000)
+    cfg.Processing.ThinkingType = getEnv("THINKING_TYPE", "enable")
+    cfg.Processing.MaxRetries = getInt("MAX_RETRIES", 3)
+    cfg.Processing.BedrockConnectTimeoutSec = getInt("BEDROCK_CONNECT_TIMEOUT_SEC", 10)
+    cfg.Processing.BedrockCallTimeoutSec = getInt("BEDROCK_CALL_TIMEOUT_SEC", 30)
+    cfg.Logging.Level = getEnv("LOG_LEVEL", "INFO")
+    cfg.Logging.Format = getEnv("LOG_FORMAT", "json")
+    cfg.Prompts.TemplateVersion = getEnv("TURN2_PROMPT_VERSION", "v1.0")
+    cfg.Prompts.TemplateBasePath = getEnv("TEMPLATE_BASE_PATH", "/opt/templates")
+    cfg.DatePartitionTimezone = getEnv("DATE_PARTITION_TIMEZONE", "UTC")
+
+    if err := cfg.Validate(); err != nil {
+        return nil, err
+    }
+    return cfg, nil
+}
+
+func mustGet(key string) (string, error) {
+    if v := os.Getenv(key); v != "" {
+        return v, nil
+    }
+    return "", errors.NewConfigError("MissingEnv", key+" is required", key)
+}
+
+func getEnv(key, def string) string {
+    if v := os.Getenv(key); v != "" {
+        return v
+    }
+    return def
+}
+
+func getInt(key string, def int) int {
+    if v := os.Getenv(key); v != "" {
+        if i, err := strconv.Atoi(v); err == nil {
+            return i
+        }
+    }
+    return def
+}
+
+func (c *Config) Validate() error {
+    if c.Processing.BedrockConnectTimeoutSec <= 0 || c.Processing.BedrockCallTimeoutSec <= 0 {
+        return errors.NewConfigError("BedrockTimeoutInvalid", "timeouts must be positive", "BEDROCK_CONNECT_TIMEOUT_SEC")
+    }
+    if c.Processing.BedrockCallTimeoutSec <= c.Processing.BedrockConnectTimeoutSec {
+        return errors.NewConfigError("BedrockTimeoutInvalid", "call timeout must be greater than connect timeout", "BEDROCK_CALL_TIMEOUT_SEC")
+    }
+    return nil
+}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/handler.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/handler.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+    "context"
+
+    "workflow-function/ExecuteTurn2Combined/internal/config"
+    "workflow-function/ExecuteTurn2Combined/internal/models"
+    "workflow-function/ExecuteTurn2Combined/internal/services"
+    "workflow-function/shared/logger"
+)
+
+// Handler orchestrates Turn2 processing
+
+type Handler struct {
+    cfg    config.Config
+    s3     services.S3StateManager
+    bedrock services.BedrockService
+    dynamo services.DynamoDBService
+    prompts services.PromptService
+    log    logger.Logger
+}
+
+func NewHandler(s3 services.S3StateManager, br services.BedrockService, dy services.DynamoDBService, pr services.PromptService, log logger.Logger, cfg *config.Config) (*Handler, error) {
+    return &Handler{cfg: *cfg, s3: s3, bedrock: br, dynamo: dy, prompts: pr, log: log}, nil
+}
+
+// Handle processes Turn 2 and returns a StepFunctionResponse
+func (h *Handler) Handle(ctx context.Context, req *models.Turn2Request) (*models.StepFunctionResponse, error) {
+    h.log.Info("turn2_start", map[string]interface{}{"verificationId": req.VerificationID})
+
+    // Load system prompt and checking image
+    systemPrompt, err := h.s3.LoadSystemPrompt(ctx, req.S3Refs.Prompts.System)
+    if err != nil {
+        return nil, err
+    }
+    imageData, err := h.s3.LoadBase64Image(ctx, req.S3Refs.Images.CheckingBase64)
+    if err != nil {
+        return nil, err
+    }
+    turn1Markdown, err := h.s3.LoadJSON(ctx, req.S3Refs.Processing.Turn1Markdown, nil)
+    if err != nil {
+        return nil, err
+    }
+
+    // Generate prompt using Turn1 markdown as context
+    prompt, err := h.prompts.GenerateTurn2Prompt(systemPrompt, imageData, turn1Markdown)
+    if err != nil {
+        return nil, err
+    }
+
+    // Call bedrock
+    resp, err := h.bedrock.Invoke(ctx, prompt, imageData)
+    if err != nil {
+        return nil, err
+    }
+
+    // Store raw response
+    rawRef, err := h.s3.StoreRawResponse(ctx, req.VerificationID, resp)
+    if err != nil {
+        return nil, err
+    }
+
+    result := &models.StepFunctionResponse{
+        VerificationID: req.VerificationID,
+        Status:         "TURN2_COMPLETED",
+        S3References:   map[string]models.S3Reference{"rawResponse": rawRef},
+    }
+
+    h.log.Info("turn2_completed", map[string]interface{}{"verificationId": req.VerificationID})
+    return result, nil
+}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/request.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/request.go
@@ -1,0 +1,34 @@
+package models
+
+// Turn2Request represents the input payload for ExecuteTurn2Combined
+// It references artifacts produced by Turn1
+
+type Turn2Request struct {
+    VerificationID      string              `json:"verificationId"`
+    VerificationContext VerificationContext `json:"verificationContext"`
+    S3Refs              Turn2RequestS3Refs  `json:"s3Refs"`
+    InputInitializationFileRef S3Reference  `json:"-"`
+}
+
+type Turn2RequestS3Refs struct {
+    Prompts    PromptRefs           `json:"prompts"`
+    Images     Turn2ImageRefs       `json:"images"`
+    Processing Turn2ProcessingRefs  `json:"processing"`
+}
+
+type Turn2ImageRefs struct {
+    CheckingBase64 S3Reference `json:"checkingBase64"`
+}
+
+type Turn2ProcessingRefs struct {
+    Turn1Markdown S3Reference `json:"turn1Markdown"`
+}
+
+// StepFunctionResponse is a simplified output for Step Functions
+// Provided here for main wrapper
+
+type StepFunctionResponse struct {
+    VerificationID string           `json:"verificationId"`
+    Status         string           `json:"status"`
+    S3References   map[string]S3Reference `json:"s3References"`
+}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/response.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/response.go
@@ -1,0 +1,11 @@
+package models
+
+import "workflow-function/shared/schema"
+
+// Turn2Response contains S3 references produced by this function
+
+type Turn2Response struct {
+    S3Refs map[string]S3Reference `json:"s3Refs"`
+    Status string                 `json:"status"`
+    Summary schema.ProcessingMetrics `json:"summary"`
+}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/shared_types.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/shared_types.go
@@ -1,0 +1,70 @@
+// internal/models/shared_types.go - CLEAN AND SIMPLE VERSION
+package models
+
+import (
+	"workflow-function/shared/schema"
+)
+
+// ===================================================================
+// LOCAL TYPE DEFINITIONS (for this function's specific needs)
+// ===================================================================
+
+// S3Reference represents a pointer to an object in S3
+type S3Reference struct {
+	Bucket string `json:"bucket"`
+	Key    string `json:"key"`
+	ETag   string `json:"etag,omitempty"`
+	Size   int64  `json:"size,omitempty"`
+}
+
+// ExecutionStage represents the current stage of processing
+type ExecutionStage string
+
+// VerificationStatus represents the current status of verification
+type VerificationStatus string
+
+// ===================================================================
+// LOCAL CONSTANTS (for backward compatibility)
+// ===================================================================
+
+// Execution stages
+const (
+	StageValidation        ExecutionStage = "validation"
+	StageContextLoading    ExecutionStage = "context_loading"
+	StagePromptGeneration  ExecutionStage = "prompt_generation"
+	StageBedrockCall       ExecutionStage = "bedrock_invocation"
+	StageProcessing        ExecutionStage = "response_processing"
+	StageStorage           ExecutionStage = "state_storage"
+	StageDynamoDB          ExecutionStage = "dynamodb_update"
+	StageReferenceAnalysis ExecutionStage = "reference_analysis"
+)
+
+// Local verification statuses
+const (
+	StatusTurn1Started        VerificationStatus = "TURN1_STARTED"
+	StatusTurn1PromptPrepared VerificationStatus = "TURN1_PROMPT_PREPARED"
+	StatusTurn1Completed      VerificationStatus = "TURN1_COMPLETED"
+)
+
+// ===================================================================
+// SCHEMA TYPE ALIASES (direct imports from shared schema)
+// ===================================================================
+
+// Core workflow types
+type (
+	SchemaVerificationContext = schema.VerificationContext
+	SchemaWorkflowState       = schema.WorkflowState
+	SchemaErrorInfo           = schema.ErrorInfo
+	SchemaStatusHistoryEntry  = schema.StatusHistoryEntry
+	SchemaProcessingMetrics   = schema.ProcessingMetrics
+	SchemaErrorTracking       = schema.ErrorTracking
+)
+
+// Enhanced response types
+type (
+	SchemaTurnResponse         = schema.TurnResponse
+	SchemaCombinedTurnResponse = schema.CombinedTurnResponse
+	SchemaProcessingStage      = schema.ProcessingStage
+)
+
+// Conversation and tracking types

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/bedrock.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/bedrock.go
@@ -1,0 +1,19 @@
+package services
+
+import "context"
+
+// BedrockService abstracts LLM invocation
+
+type BedrockService interface {
+    Invoke(ctx context.Context, prompt string, imageData string) (interface{}, error)
+}
+
+func NewBedrockService(log interface{}) BedrockService {
+    return &noopBedrock{}
+}
+
+type noopBedrock struct{}
+
+func (n *noopBedrock) Invoke(ctx context.Context, prompt string, imageData string) (interface{}, error) {
+    return map[string]interface{}{"message": "ok"}, nil
+}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go
@@ -1,0 +1,17 @@
+package services
+
+import "context"
+
+// DynamoDBService abstracts DynamoDB operations
+
+type DynamoDBService interface {
+    UpdateTurn2Completion(ctx context.Context, verificationID string) error
+}
+
+func NewDynamoDBService(cfg interface{}) (DynamoDBService, error) {
+    return &noopDynamo{}, nil
+}
+
+type noopDynamo struct{}
+
+func (n *noopDynamo) UpdateTurn2Completion(ctx context.Context, verificationID string) error { return nil }

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/prompt.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/prompt.go
@@ -1,0 +1,17 @@
+package services
+
+// PromptService generates prompts for Turn 2
+
+type PromptService interface {
+    GenerateTurn2Prompt(systemPrompt string, imageData string, previousAnalysis interface{}) (string, error)
+}
+
+func NewPromptService(cfg interface{}, log interface{}) (PromptService, error) {
+    return &noopPrompt{}, nil
+}
+
+type noopPrompt struct{}
+
+func (n *noopPrompt) GenerateTurn2Prompt(systemPrompt string, imageData string, previousAnalysis interface{}) (string, error) {
+    return systemPrompt, nil
+}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+    "context"
+
+    "workflow-function/ExecuteTurn2Combined/internal/models"
+)
+
+type S3StateManager interface {
+    LoadSystemPrompt(ctx context.Context, ref models.S3Reference) (string, error)
+    LoadBase64Image(ctx context.Context, ref models.S3Reference) (string, error)
+    LoadJSON(ctx context.Context, ref models.S3Reference, target interface{}) error
+    StoreRawResponse(ctx context.Context, verificationID string, data interface{}) (models.S3Reference, error)
+}
+
+// NewS3StateManager returns a no-op manager for this skeleton implementation
+func NewS3StateManager(cfg interface{}, log interface{}) (S3StateManager, error) {
+    return &noopS3Manager{}, nil
+}
+
+type noopS3Manager struct{}
+
+func (n *noopS3Manager) LoadSystemPrompt(ctx context.Context, ref models.S3Reference) (string, error) { return "", nil }
+func (n *noopS3Manager) LoadBase64Image(ctx context.Context, ref models.S3Reference) (string, error) { return "", nil }
+func (n *noopS3Manager) LoadJSON(ctx context.Context, ref models.S3Reference, target interface{}) error { return nil }
+func (n *noopS3Manager) StoreRawResponse(ctx context.Context, verificationID string, data interface{}) (models.S3Reference, error) {
+    return models.S3Reference{}, nil
+}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/validation/validator.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/validation/validator.go
@@ -1,0 +1,5 @@
+package validation
+
+import "workflow-function/ExecuteTurn2Combined/internal/models"
+
+func ValidateRequest(req *models.Turn2Request) error { return nil }

--- a/product-approach/workflow-function/ExecuteTurn2Combined/retry-docker-build.sh
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/retry-docker-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+REPO=$1
+FUNC=$2
+REGION=${3:-us-east-1}
+
+for i in {1..3}; do
+  docker build -t "$REPO:$FUNC" . && break
+  sleep 2
+done


### PR DESCRIPTION
## Summary
- create ExecuteTurn2Combined lambda skeleton with config, handler, services and models
- add Dockerfile and build helper
- document initial design in README and CHANGELOG

## Testing
- `gofmt -w product-approach/workflow-function/ExecuteTurn2Combined/internal/**/*.go`
- `cd product-approach/workflow-function/ExecuteTurn2Combined && GOWORK=off go list ./...` *(fails: missing go.sum entries due to network restrictions)*