### PR TITLE
Fix compile errors in ExecuteTurn2Combined

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to the ExecuteTurn2Combined function will be documented in t
 - Updated `S3StateManager` interface to include Turn 2 storage helpers.
 - Adjusted `Turn2Handler` to use `VerificationContext` fields and updated processing metrics structure.
 
+## [1.3.2] - 2025-06-07
+### Fixed
+- Added `LoadTurn1ProcessedResponse` and `LoadTurn1RawResponse` to `S3StateManager` interface.
+- Corrected unused variables and token usage fields in `Turn2Handler`.
+- Defined `ErrorTypeTemplate` for template rendering errors.
+
 ## [1.3.0] - 2025-06-05
 ### Added
 - **Business Logic for Discrepancy Interpretation**:

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/turn2_handler.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/turn2_handler.go
@@ -110,7 +110,7 @@ func (h *Turn2Handler) ProcessTurn2Request(ctx context.Context, req *models.Turn
 	}
 
 	// Store prompt processor metrics
-	promptProcessorRef, err := h.s3Service.StoreTemplateProcessor(ctx, req.VerificationID, promptProcessor)
+	_, err = h.s3Service.StoreTemplateProcessor(ctx, req.VerificationID, promptProcessor)
 	if err != nil {
 		h.log.Warn("failed_to_store_prompt_processor", map[string]interface{}{
 			"error":           err.Error(),
@@ -172,7 +172,7 @@ func (h *Turn2Handler) ProcessTurn2Request(ctx context.Context, req *models.Turn
 	}
 
 	// Store markdown response
-	markdownRef, err := h.s3Service.StoreTurn2Markdown(ctx, req.VerificationID, markdownResponse)
+	_, err = h.s3Service.StoreTurn2Markdown(ctx, req.VerificationID, markdownResponse.ComparisonMarkdown)
 	if err != nil {
 		h.log.Warn("failed_to_store_markdown_response", map[string]interface{}{
 			"error":           err.Error(),
@@ -239,7 +239,7 @@ func (h *Turn2Handler) ProcessTurn2Request(ctx context.Context, req *models.Turn
 	}
 
 	// Store processing metrics
-	metricsRef, err := h.s3Service.StoreProcessingMetrics(ctx, req.VerificationID, processingMetrics)
+	_, err = h.s3Service.StoreProcessingMetrics(ctx, req.VerificationID, processingMetrics)
 	if err != nil {
 		h.log.Warn("failed_to_store_processing_metrics", map[string]interface{}{
 			"error":           err.Error(),
@@ -259,10 +259,10 @@ func (h *Turn2Handler) ProcessTurn2Request(ctx context.Context, req *models.Turn
 			AnalysisStage:    models.StageProcessing,
 			ProcessingTimeMs: processingMetrics.Turn2.TotalTimeMs,
 			TokenUsage: models.TokenUsage{
-				InputTokens:  bedrockResponse.InputTokens,
-				OutputTokens: bedrockResponse.OutputTokens,
-				Thinking:     0,
-				Total:        bedrockResponse.InputTokens + bedrockResponse.OutputTokens,
+				InputTokens:    bedrockResponse.InputTokens,
+				OutputTokens:   bedrockResponse.OutputTokens,
+				ThinkingTokens: 0,
+				TotalTokens:    bedrockResponse.InputTokens + bedrockResponse.OutputTokens,
 			},
 			BedrockRequestID: "",
 		},

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
@@ -146,6 +146,10 @@ type S3StateManager interface {
 	StoreProcessingMetrics(ctx context.Context, verificationID string, metrics *schema.ProcessingMetrics) (models.S3Reference, error)
 	LoadProcessingState(ctx context.Context, verificationID string, stateType string) (interface{}, error)
 
+	// Turn1 specific loaders used by ExecuteTurn2Combined
+	LoadTurn1ProcessedResponse(ctx context.Context, ref models.S3Reference) (*schema.Turn1ProcessedResponse, error)
+	LoadTurn1RawResponse(ctx context.Context, ref models.S3Reference) (json.RawMessage, error)
+
 	// Turn2 specific storage helpers
 	StoreTurn2Response(ctx context.Context, verificationID string, response *bedrockparser.ParsedTurn2Data) (models.S3Reference, error)
 	StoreTurn2Markdown(ctx context.Context, verificationID string, markdownContent string) (models.S3Reference, error)

--- a/product-approach/workflow-function/shared/errors/errors.go
+++ b/product-approach/workflow-function/shared/errors/errors.go
@@ -18,17 +18,19 @@ type APIErrorSource string
 
 // Error types
 const (
-	ErrorTypeValidation   ErrorType = "ValidationException"
-	ErrorTypeAPI          ErrorType = "APIException"
-	ErrorTypeBedrock      ErrorType = "BedrockException"
-	ErrorTypeConverse     ErrorType = "ConverseException"
-	ErrorTypeS3           ErrorType = "S3Exception"
-	ErrorTypeDynamoDB     ErrorType = "DynamoDBException"
-	ErrorTypeInternal     ErrorType = "InternalException"
-	ErrorTypeTimeout      ErrorType = "TimeoutException"
-	ErrorTypeRetryable    ErrorType = "RetryableException"
-	ErrorTypeConversion   ErrorType = "ConversionException"
-	ErrorTypeConfig       ErrorType = "ConfigException"
+	ErrorTypeValidation ErrorType = "ValidationException"
+	ErrorTypeAPI        ErrorType = "APIException"
+	ErrorTypeBedrock    ErrorType = "BedrockException"
+	ErrorTypeConverse   ErrorType = "ConverseException"
+	ErrorTypeS3         ErrorType = "S3Exception"
+	ErrorTypeDynamoDB   ErrorType = "DynamoDBException"
+	ErrorTypeInternal   ErrorType = "InternalException"
+	// ErrorTypeTemplate represents errors encountered during template processing
+	ErrorTypeTemplate   ErrorType = "TemplateException"
+	ErrorTypeTimeout    ErrorType = "TimeoutException"
+	ErrorTypeRetryable  ErrorType = "RetryableException"
+	ErrorTypeConversion ErrorType = "ConversionException"
+	ErrorTypeConfig     ErrorType = "ConfigException"
 )
 
 // Error severities
@@ -41,9 +43,9 @@ const (
 
 // API sources
 const (
-	APISourceLegacy    APIErrorSource = "InvokeModel"
-	APISourceConverse  APIErrorSource = "Converse"
-	APISourceUnknown   APIErrorSource = "Unknown"
+	APISourceLegacy   APIErrorSource = "InvokeModel"
+	APISourceConverse APIErrorSource = "Converse"
+	APISourceUnknown  APIErrorSource = "Unknown"
 )
 
 // WorkflowError represents a structured error for workflow functions


### PR DESCRIPTION
## Summary
- add `ErrorTypeTemplate`
- expose Turn1 loading helpers in `S3StateManager`
- clean up unused vars in `Turn2Handler` and fix token usage fields
- document the fix in `CHANGELOG`

## Testing
- `GOWORK=off go vet ./...` *(fails: no route to host)*