### PR TITLE
Fix Turn2 handler helper compile error

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the ExecuteTurn2Combined function will be documented in t
 - Wired `PromptServiceTurn2` into `turn2_handler.go`
 ### Fixed
 - Ensured DynamoDB statuses now include `TURN2_COMPLETED`
+- Resolved compilation error by renaming helper method receivers to `Turn2Handler`
 
 ## [1.3.1] - 2025-06-06
 ### Fixed

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/helpers.go
@@ -246,7 +246,7 @@ func calculateHoursSince(timestamp string) float64 {
 }
 
 // Helper function to extract image reference URL from request
-func (h *Handler) ImageRef(req *models.Turn1Request) string {
+func (h *Turn2Handler) ImageRef(req *models.Turn1Request) string {
 	if req != nil && req.S3Refs.Images.ReferenceBase64.Key != "" {
 		return req.S3Refs.Images.ReferenceBase64.Key
 	}


### PR DESCRIPTION
## Summary
- rename helper method receivers to `Turn2Handler`
- update ExecuteTurn2Combined changelog

## Testing
- `go build ./...` *(fails: cannot load module ../ExecuteTurn1 listed in go.work file: open ../ExecuteTurn1/go.mod: no such file or directory)*