### PR TITLE
Dynamic format for checking image in Turn2

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to the ExecuteTurn2Combined function will be documented in t
 - Ensured DynamoDB statuses now include `TURN2_COMPLETED`
 - Resolved compilation error by renaming helper method receivers to `Turn2Handler`
 
+## [1.3.4] - 2025-05-28
+### Changed
+- Modified `internal/bedrock/adapter_turn2.go` in `ConverseWithHistory` to use the actual checking image format rather than a hardcoded `"jpeg"`.
+- Updated method signatures throughout the call chain (`client_turn2.go`, `services/bedrock_turn2.go`, `handler/turn2_handler.go`) to pass the checking image format from `ContextLoader`.
+- `ContextLoader` now loads image metadata to determine the checking image format.
+
 ## [1.3.1] - 2025-06-06
 ### Fixed
 - Resolved compilation errors due to outdated struct fields and renamed parser functions.

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client_turn2.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"workflow-function/ExecuteTurn2Combined/internal/config"
+	sharedBedrock "workflow-function/shared/bedrock"
 	"workflow-function/shared/errors"
 	"workflow-function/shared/logger"
 	"workflow-function/shared/schema"
-	sharedBedrock "workflow-function/shared/bedrock"
 )
 
 // ClientTurn2 extends Client with Turn2-specific functionality
@@ -65,7 +65,8 @@ func NewClientTurn2(cfg config.Config, log logger.Logger) (*ClientTurn2, error) 
 }
 
 // ProcessTurn2 handles the complete Turn2 processing
-func (c *ClientTurn2) ProcessTurn2(ctx context.Context, systemPrompt, turn2Prompt, base64Image string, turn1Response *schema.Turn1ProcessedResponse) (*schema.BedrockResponse, error) {
+// MODIFICATION START: added imageFormat parameter
+func (c *ClientTurn2) ProcessTurn2(ctx context.Context, systemPrompt, turn2Prompt, base64Image, imageFormat string, turn1Response *schema.Turn1ProcessedResponse) (*schema.BedrockResponse, error) {
 	startTime := time.Now()
 
 	// Validate configuration
@@ -74,7 +75,7 @@ func (c *ClientTurn2) ProcessTurn2(ctx context.Context, systemPrompt, turn2Promp
 	}
 
 	// Process Turn2 using adapter
-	response, err := c.adapterTurn2.ProcessTurn2(ctx, systemPrompt, turn2Prompt, base64Image, turn1Response)
+	response, err := c.adapterTurn2.ProcessTurn2(ctx, systemPrompt, turn2Prompt, base64Image, imageFormat, turn1Response)
 	if err != nil {
 		return nil, err
 	}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/turn2_handler.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/turn2_handler.go
@@ -137,13 +137,14 @@ func (h *Turn2Handler) ProcessTurn2Request(ctx context.Context, req *models.Turn
 	}
 
 	// Invoke Bedrock with conversation history
-	bedrockResponse, err := h.bedrock.ConverseWithHistory(
-		ctx,
-		loadResult.SystemPrompt,
-		prompt,
-		loadResult.Base64Image,
-		loadResult.Turn1Response,
-	)
+       bedrockResponse, err := h.bedrock.ConverseWithHistory(
+               ctx,
+               loadResult.SystemPrompt,
+               prompt,
+               loadResult.Base64Image,
+               loadResult.ImageFormat,
+               loadResult.Turn1Response,
+       )
 	if err != nil {
 		wfErr := errors.WrapError(err, errors.ErrorTypeBedrock,
 			"failed to invoke Bedrock for Turn2", true).

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/bedrock_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/bedrock_turn2.go
@@ -14,7 +14,9 @@ type BedrockServiceTurn2 interface {
 	BedrockService
 
 	// ConverseWithHistory handles Turn2 conversation with history from Turn1
-	ConverseWithHistory(ctx context.Context, systemPrompt, turn2Prompt, base64Image string, turn1Response *schema.Turn1ProcessedResponse) (*schema.BedrockResponse, error)
+	// MODIFICATION START: added imageFormat parameter
+	ConverseWithHistory(ctx context.Context, systemPrompt, turn2Prompt, base64Image, imageFormat string, turn1Response *schema.Turn1ProcessedResponse) (*schema.BedrockResponse, error)
+	// MODIFICATION END
 }
 
 // bedrockServiceTurn2 implements BedrockServiceTurn2
@@ -44,6 +46,6 @@ func NewBedrockServiceTurn2(cfg config.Config, log logger.Logger) (BedrockServic
 }
 
 // ConverseWithHistory handles Turn2 conversation with history from Turn1
-func (s *bedrockServiceTurn2) ConverseWithHistory(ctx context.Context, systemPrompt, turn2Prompt, base64Image string, turn1Response *schema.Turn1ProcessedResponse) (*schema.BedrockResponse, error) {
-	return s.clientTurn2.ProcessTurn2(ctx, systemPrompt, turn2Prompt, base64Image, turn1Response)
+func (s *bedrockServiceTurn2) ConverseWithHistory(ctx context.Context, systemPrompt, turn2Prompt, base64Image, imageFormat string, turn1Response *schema.Turn1ProcessedResponse) (*schema.BedrockResponse, error) {
+	return s.clientTurn2.ProcessTurn2(ctx, systemPrompt, turn2Prompt, base64Image, imageFormat, turn1Response)
 }


### PR DESCRIPTION
## Summary
- load checking image metadata in `ContextLoader` to capture format
- pass the format through the service, client, and adapter layers
- use `NormalizeImageFormat` when building Bedrock requests
- update changelog with new version entry

## Testing
- `go vet ./product-approach/workflow-function/ExecuteTurn2Combined/...` *(fails: cannot load modules due to workspace setup)*