### PR TITLE
Fix Turn2 output summary fields

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -38,6 +38,17 @@ All notable changes to the ExecuteTurn2Combined function will be documented in t
 - Added stub implementations for `Handle` and `HandleForStepFunction` to satisfy
   compiler requirements.
 
+## [1.3.5] - 2025-06-09
+### Fixed
+- `AdapterTurn2` now receives the checking image format from the handler, allowing
+  dynamic handling of `jpeg` or `png` images instead of a hardcoded format.
+- `ContextLoader` consumes the direct S3 reference for the checking image Base64
+  data, ensuring Turn 2 context loads without errors.
+- `Turn2Handler` now populates full Turn 2 response data including S3 references
+  for raw and processed outputs, updates status to `TURN2_COMPLETED`, and fills
+  new summary fields (`discrepanciesFound`, `verificationOutcome`,
+  `comparisonCompleted`, `conversationCompleted`, `dynamodbUpdated`).
+
 ## [1.3.0] - 2025-06-05
 ### Added
 - **Business Logic for Discrepancy Interpretation**:

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/request.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/request.go
@@ -83,6 +83,12 @@ type Summary struct {
 	ProcessingTimeMs int64          `json:"processingTimeMs"`
 	TokenUsage       TokenUsage     `json:"tokenUsage"`
 	BedrockRequestID string         `json:"bedrockRequestId"`
+	// Additional fields aligned with expected Turn2 output structure
+	DiscrepanciesFound    *int   `json:"discrepanciesFound,omitempty"`
+	VerificationOutcome   string `json:"verificationOutcome,omitempty"`
+	ComparisonCompleted   *bool  `json:"comparisonCompleted,omitempty"`
+	ConversationCompleted *bool  `json:"conversationCompleted,omitempty"`
+	DynamodbUpdated       *bool  `json:"dynamodbUpdated,omitempty"`
 }
 
 // Discrepancy represents a single discrepancy found during verification.


### PR DESCRIPTION
## Summary
- ensure Turn2 summary includes verification and completion details
- pass Bedrock request ID and dynamic checking image format
- document fixes in CHANGELOG

## Testing
- `go test ./...` *(fails: cannot load module ../ExecuteTurn1 listed in go.work file: open ../ExecuteTurn1/go.mod: no such file or directory)*