### PR TITLE
Refactor Turn2 prompt and output handling

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.1.0] - 2025-06-30 - Simplified Turn2 Processing
+
+### Added
+- Simplified Turn2 prompt generation with a static instruction template.
+- Envelope-based storage of Turn2 raw and processed responses via `SaveToEnvelope`.
+- Nested `turn2Raw` and `turn2Processed` references under `responses` in output structures.
+- Unit tests for the new storage manager and response builder.
+
+### Changed
+- Turn1 data is loaded only for conversation history.
+- Output S3 reference schema standardized for Turn2.
+- Logging and status tracking aligned with Turn2 operations.
+- Fixed initialization.json path resolution in `EventTransformer`.
+
 ## [2.0.7] - 2025-05-29 - Critical Reliability Fixes
 
 ### 🚨 **Critical Bug Fixes: S3 and DynamoDB Retry Logic**

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/response_builder_test.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/response_builder_test.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"testing"
+
+	"workflow-function/ExecuteTurn2Combined/internal/config"
+	"workflow-function/ExecuteTurn2Combined/internal/models"
+)
+
+func TestBuildTurn2StepFunctionResponseRefs(t *testing.T) {
+	builder := NewResponseBuilder(config.Config{})
+	req := &models.Turn2Request{
+		VerificationID: "verif-1",
+		S3Refs: models.Turn2RequestS3Refs{
+			Prompts: models.PromptRefs{System: models.S3Reference{Bucket: "b", Key: "sys"}},
+			Images:  models.Turn2ImageRefs{CheckingBase64: models.S3Reference{Bucket: "b", Key: "img"}},
+			Turn1: models.Turn1References{
+				RawResponse:       models.S3Reference{Bucket: "b", Key: "t1raw"},
+				ProcessedResponse: models.S3Reference{Bucket: "b", Key: "t1proc"},
+			},
+		},
+	}
+	resp := &models.Turn2Response{
+		S3Refs: models.Turn2ResponseS3Refs{
+			RawResponse:       models.S3Reference{Bucket: "b", Key: "raw"},
+			ProcessedResponse: models.S3Reference{Bucket: "b", Key: "proc"},
+		},
+		Status: models.StatusTurn2Completed,
+	}
+
+	out := builder.BuildTurn2StepFunctionResponse(req, resp)
+	responses := out.S3References["responses"].(map[string]interface{})
+	if responses["turn2Raw"].(models.S3Reference).Key != "raw" {
+		t.Fatalf("missing turn2Raw")
+	}
+	if responses["turn2Processed"].(models.S3Reference).Key != "proc" {
+		t.Fatalf("missing turn2Processed")
+	}
+}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/storage_manager.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/storage_manager.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+
+	"workflow-function/ExecuteTurn2Combined/internal/models"
+	"workflow-function/shared/logger"
+	"workflow-function/shared/s3state"
+)
+
+// StorageManager handles saving Turn2 artifacts to S3 using an envelope
+// and exposes the resulting references in models.S3Reference format.
+type StorageManager struct {
+	manager s3state.Manager
+	log     logger.Logger
+}
+
+func NewStorageManager(manager s3state.Manager, log logger.Logger) *StorageManager {
+	return &StorageManager{manager: manager, log: log}
+}
+
+// SaveTurn2Outputs stores the raw Bedrock response and the processed analysis
+// into the provided envelope. The references are also mapped to concise keys
+// (turn2Raw and turn2Processed) for downstream use.
+func (s *StorageManager) SaveTurn2Outputs(ctx context.Context, envelope *s3state.Envelope, raw []byte, processed interface{}) (models.S3Reference, models.S3Reference, error) {
+	if envelope == nil {
+		return models.S3Reference{}, models.S3Reference{}, nil
+	}
+
+	// Save raw bytes
+	if err := s.manager.SaveToEnvelope(envelope, "responses", "turn2-raw-response.json", json.RawMessage(raw)); err != nil {
+		return models.S3Reference{}, models.S3Reference{}, err
+	}
+	rawRef := envelope.GetReference("responses_turn2-raw-response")
+	if rawRef != nil {
+		envelope.AddReference("turn2Raw", rawRef)
+	}
+
+	// Save processed structure
+	if err := s.manager.SaveToEnvelope(envelope, "responses", "turn2-processed-response.json", processed); err != nil {
+		return models.S3Reference{}, models.S3Reference{}, err
+	}
+	procRef := envelope.GetReference("responses_turn2-processed-response")
+	if procRef != nil {
+		envelope.AddReference("turn2Processed", procRef)
+	}
+
+	return toModelRef(rawRef), toModelRef(procRef), nil
+}
+
+func toModelRef(ref *s3state.Reference) models.S3Reference {
+	if ref == nil {
+		return models.S3Reference{}
+	}
+	return models.S3Reference{Bucket: ref.Bucket, Key: ref.Key, Size: ref.Size}
+}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/storage_manager_test.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/storage_manager_test.go
@@ -1,0 +1,50 @@
+package handler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"workflow-function/shared/logger"
+	"workflow-function/shared/s3state"
+)
+
+type stubS3Manager struct{}
+
+func (s *stubS3Manager) Store(category, key string, data []byte) (*s3state.Reference, error) {
+	return nil, nil
+}
+func (s *stubS3Manager) StoreWithContentType(category, key string, data []byte, ct string) (*s3state.Reference, error) {
+	return nil, nil
+}
+func (s *stubS3Manager) Retrieve(ref *s3state.Reference) ([]byte, error) { return nil, nil }
+func (s *stubS3Manager) StoreJSON(category, key string, data interface{}) (*s3state.Reference, error) {
+	return &s3state.Reference{Bucket: "b", Key: category + "/" + key}, nil
+}
+func (s *stubS3Manager) RetrieveJSON(ref *s3state.Reference, target interface{}) error { return nil }
+func (s *stubS3Manager) SaveToEnvelope(env *s3state.Envelope, category, filename string, data interface{}) error {
+	ref := &s3state.Reference{Bucket: "b", Key: category + "/" + filename}
+	env.AddReference(category+"_"+strings.TrimSuffix(filename, ".json"), ref)
+	return nil
+}
+func (s *stubS3Manager) GetStateBucket() string { return "b" }
+
+func TestSaveTurn2Outputs(t *testing.T) {
+	env := s3state.NewEnvelope("verif-1")
+	mgr := &stubS3Manager{}
+	sm := NewStorageManager(mgr, logger.New("test", "test"))
+
+	raw := []byte("{}")
+	proc := map[string]string{"a": "b"}
+
+	rawRef, procRef, err := sm.SaveTurn2Outputs(context.Background(), env, raw, proc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if env.GetReference("turn2Raw") == nil || env.GetReference("turn2Processed") == nil {
+		t.Fatalf("references not stored")
+	}
+	if rawRef.Key == "" || procRef.Key == "" {
+		t.Fatalf("empty refs")
+	}
+}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
@@ -159,6 +159,9 @@ type S3StateManager interface {
 	// STRATEGIC: Schema-based workflow state operations
 	StoreWorkflowState(ctx context.Context, verificationID string, state *schema.WorkflowState) (models.S3Reference, error)
 	LoadWorkflowState(ctx context.Context, verificationID string) (*schema.WorkflowState, error)
+
+	// Manager exposes the underlying s3state.Manager for advanced operations
+	Manager() s3state.Manager
 }
 
 // ===================================================================
@@ -992,6 +995,11 @@ func (m *s3Manager) fromStateReference(ref *s3state.Reference) models.S3Referenc
 		Key:    ref.Key,
 		Size:   ref.Size,
 	}
+}
+
+// Manager returns the underlying s3state.Manager for advanced operations
+func (m *s3Manager) Manager() s3state.Manager {
+	return m.stateManager
 }
 
 // truncateForLog provides safe string truncation for logging


### PR DESCRIPTION
## Summary
- add StorageManager for Turn2 that saves raw and processed outputs via `SaveToEnvelope`
- expose underlying s3state manager
- simplify Turn2 prompt to static text
- store raw and processed references using new manager
- test storage manager and response builder
- document changes in changelog

## Testing
- `go test ./...` *(fails: no network access)*