### PR TITLE
Fix StepFunction response to include prompt path

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the ExecuteTurn1Combined function will be documented in t
 ### Added
 - Execution status is now written back to the input `initialization.json` after processing. The handler updates `verificationContext.status` and `lastUpdatedAt` and stores the file back to the original S3 location.
 
+## [2.4.8] - 2025-06-04
+### Fixed
+- Step Function output now includes `prompts_turn1` referencing the stored Turn 1 prompt path.
+
 ## [2.4.6] - 2025-06-02
 ### Fixed
 - Corrected the S3 path for the processed Turn 1 Markdown response. The file is now stored under the `response/` directory instead of `processing/`.

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/response_builder.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/response_builder.go
@@ -108,6 +108,10 @@ func (r *ResponseBuilder) BuildStepFunctionResponse(
 		},
 	}
 
+	if s3RefTree.Prompts.Turn1Prompt.Key != "" {
+		s3References["prompts_turn1"] = s3RefTree.Prompts.Turn1Prompt
+	}
+
 	if s3RefTree.Processing.LayoutMetadata.Key != "" {
 		s3References["processing_layout-metadata"] = s3RefTree.Processing.LayoutMetadata
 	}


### PR DESCRIPTION
## Summary
- export Turn 1 prompt S3 path in the StepFunction response
- document change in changelog

## Testing
- `go test ./...` *(fails: cannot load module product-approach/workflow-function/ExecuteTurn1 listed in go.work file)*