### PR TITLE
Store Turn2 prompt reference

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.2.4] - 2025-05-29 - Add Turn 2 Prompt Reference
+### Added
+- Persisted Turn 2 prompt to S3 using `SaveToEnvelope` under `prompts/turn2-prompt.json`.
+- Storage manager exposes `SaveTurn2Prompt` and unit test ensures reference creation.
+- `PromptRefs` model includes new `turn2Prompt` field.
+
 ## [2.1.0] - 2025-06-30 - Simplified Turn2 Processing
 
 ### Added

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/storage_manager.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/storage_manager.go
@@ -49,6 +49,24 @@ func (s *StorageManager) SaveTurn2Outputs(ctx context.Context, envelope *s3state
 	return toModelRef(rawRef), toModelRef(procRef), nil
 }
 
+// SaveTurn2Prompt stores the rendered Turn2 prompt into the envelope and returns the reference.
+func (s *StorageManager) SaveTurn2Prompt(ctx context.Context, envelope *s3state.Envelope, prompt string) (models.S3Reference, error) {
+	if envelope == nil {
+		return models.S3Reference{}, nil
+	}
+
+	if err := s.manager.SaveToEnvelope(envelope, "prompts", "turn2-prompt.json", json.RawMessage([]byte(prompt))); err != nil {
+		return models.S3Reference{}, err
+	}
+
+	ref := envelope.GetReference("prompts_turn2-prompt")
+	if ref != nil {
+		envelope.AddReference("prompts_turn2", ref)
+		return toModelRef(ref), nil
+	}
+	return models.S3Reference{}, nil
+}
+
 func toModelRef(ref *s3state.Reference) models.S3Reference {
 	if ref == nil {
 		return models.S3Reference{}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/storage_manager_test.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/storage_manager_test.go
@@ -48,3 +48,20 @@ func TestSaveTurn2Outputs(t *testing.T) {
 		t.Fatalf("empty refs")
 	}
 }
+
+func TestSaveTurn2Prompt(t *testing.T) {
+	env := s3state.NewEnvelope("verif-1")
+	mgr := &stubS3Manager{}
+	sm := NewStorageManager(mgr, logger.New("test", "test"))
+
+	ref, err := sm.SaveTurn2Prompt(context.Background(), env, "test prompt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if env.GetReference("prompts_turn2") == nil {
+		t.Fatalf("prompt reference not stored")
+	}
+	if ref.Key == "" {
+		t.Fatalf("empty ref")
+	}
+}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/request.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/request.go
@@ -38,7 +38,8 @@ type Turn2ImageRefs struct {
 
 // PromptRefs holds S3 locations for prompt artifacts.
 type PromptRefs struct {
-	System S3Reference `json:"system"` // system-prompt.json
+	System      S3Reference `json:"system"` // system-prompt.json
+	Turn2Prompt S3Reference `json:"turn2Prompt"`
 }
 
 // ImageRefs holds S3 locations for image artifacts.


### PR DESCRIPTION
## Summary
- save Turn2 prompt to S3 envelope
- expose Turn2 prompt reference model field
- test new SaveTurn2Prompt helper
- document Turn2 prompt reference addition

## Testing
- `go test ./...` *(fails: cannot load module ../ExecuteTurn1 listed in go.work file)*