### PR TITLE
Store turn1 conversation history

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to the ExecuteTurn1Combined function will be documented in this file.
+## [2.5.0] - 2025-05-30
+### Added
+- `ExecuteTurn1Combined` now captures the full conversation history for Turn 1 and stores it as `turn1-conversation.json` in S3.
+- DynamoDB tables updated with a reference to the new conversation file.
+- Step Function output includes `conversation.turn1` S3 reference.
 ## [2.4.7] - 2025-06-03
 ### Added
 - Execution status is now written back to the input `initialization.json` after processing. The handler updates `verificationContext.status` and `lastUpdatedAt` and stores the file back to the original S3 location.

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager.go
@@ -32,6 +32,7 @@ func (d *DynamoManager) UpdateTurn1Completion(
 	turnEntry *schema.TurnResponse,
 	turn1Metrics *schema.TurnMetrics,
 	processedMarkdownRef *models.S3Reference,
+	conversationRef *models.S3Reference,
 ) bool {
 	dynamoOK := true
 
@@ -51,7 +52,7 @@ func (d *DynamoManager) UpdateTurn1Completion(
 		dynamoOK = false
 	}
 
-	if err := d.dynamo.UpdateTurn1CompletionDetails(ctx, verificationID, initialVerificationAt, statusEntry, turn1Metrics, processedMarkdownRef); err != nil {
+	if err := d.dynamo.UpdateTurn1CompletionDetails(ctx, verificationID, initialVerificationAt, statusEntry, turn1Metrics, processedMarkdownRef, conversationRef); err != nil {
 		d.log.Warn("dynamodb update turn1 completion details failed", map[string]interface{}{
 			"error":     err.Error(),
 			"retryable": errors.IsRetryable(err),

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/helpers.go
@@ -11,11 +11,12 @@ import (
 
 // S3ReferenceTree represents a complete tree of S3 references for a verification
 type S3ReferenceTree struct {
-	Initialization models.S3Reference   `json:"initialization,omitempty"`
-	Images         ImageReferences      `json:"images,omitempty"`
-	Processing     ProcessingReferences `json:"processing,omitempty"`
-	Prompts        PromptReferences     `json:"prompts,omitempty"`
-	Responses      ResponseReferences   `json:"responses,omitempty"`
+	Initialization models.S3Reference     `json:"initialization,omitempty"`
+	Images         ImageReferences        `json:"images,omitempty"`
+	Processing     ProcessingReferences   `json:"processing,omitempty"`
+	Prompts        PromptReferences       `json:"prompts,omitempty"`
+	Conversation   ConversationReferences `json:"conversation,omitempty"`
+	Responses      ResponseReferences     `json:"responses,omitempty"`
 }
 
 // PromptReferences holds S3 references for prompt artifacts
@@ -36,6 +37,12 @@ type ImageReferences struct {
 type ProcessingReferences struct {
 	HistoricalContext models.S3Reference `json:"historicalContext,omitempty"`
 	LayoutMetadata    models.S3Reference `json:"layoutMetadata,omitempty"`
+}
+
+// ConversationReferences holds references for conversation history
+type ConversationReferences struct {
+	Turn1 models.S3Reference `json:"turn1,omitempty"`
+	Turn2 models.S3Reference `json:"turn2,omitempty"`
 }
 
 // ResponseReferences holds S3 references for response artifacts
@@ -70,7 +77,7 @@ type TokenUsageDetailed struct {
 // buildS3RefTree constructs a unified S3 reference tree from various sources
 func buildS3RefTree(
 	base models.Turn1RequestS3Refs,
-	promptRef, rawRef, procRef models.S3Reference,
+	promptRef, rawRef, procRef, convRef models.S3Reference,
 ) S3ReferenceTree {
 	// Extract verification ID from the key pattern
 	verificationID := extractVerificationID(rawRef.Key)
@@ -123,6 +130,9 @@ func buildS3RefTree(
 		},
 		Prompts: PromptReferences{
 			SystemPrompt: base.Prompts.System,
+		},
+		Conversation: ConversationReferences{
+			Turn1: convRef,
 		},
 		Responses: ResponseReferences{
 			Turn1Raw:       rawRef,

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/dynamo_manager.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/dynamo_manager.go
@@ -63,7 +63,7 @@ func (d *DynamoManager) UpdateTurn1Completion(
 		dynamoOK = false
 	}
 
-	if err := d.dynamo.UpdateTurn1CompletionDetails(ctx, verificationID, initialVerificationAt, statusEntry, turn1Metrics, processedMarkdownRef); err != nil {
+	if err := d.dynamo.UpdateTurn1CompletionDetails(ctx, verificationID, initialVerificationAt, statusEntry, turn1Metrics, processedMarkdownRef, nil); err != nil {
 		d.log.Warn("dynamodb update turn1 completion details failed", map[string]interface{}{
 			"error":     err.Error(),
 			"retryable": errors.IsRetryable(err),

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go
@@ -36,7 +36,7 @@ type DynamoDBService interface {
 	UpdateErrorTracking(ctx context.Context, verificationID string, errorTracking *schema.ErrorTracking) error
 
 	// Turn1 completion update storing metrics and processed markdown reference
-	UpdateTurn1CompletionDetails(ctx context.Context, verificationID string, verificationAt string, statusEntry schema.StatusHistoryEntry, turn1Metrics *schema.TurnMetrics, processedMarkdownRef *models.S3Reference) error
+	UpdateTurn1CompletionDetails(ctx context.Context, verificationID string, verificationAt string, statusEntry schema.StatusHistoryEntry, turn1Metrics *schema.TurnMetrics, processedMarkdownRef *models.S3Reference, conversationRef *models.S3Reference) error
 	// Turn2 completion update storing metrics and comparison details
 	UpdateTurn2CompletionDetails(ctx context.Context, verificationID string, verificationAt string, statusEntry schema.StatusHistoryEntry, turn2Metrics *schema.TurnMetrics, verificationStatus string, discrepancies []schema.Discrepancy, comparisonSummary string) error
 
@@ -623,6 +623,7 @@ func (d *dynamoClient) UpdateTurn1CompletionDetails(
 	statusEntry schema.StatusHistoryEntry,
 	turn1Metrics *schema.TurnMetrics,
 	processedMarkdownRef *models.S3Reference,
+	conversationRef *models.S3Reference,
 ) error {
 	if verificationID == "" || verificationAt == "" {
 		return errors.NewValidationError("VerificationID and VerificationAt are required", nil)
@@ -654,6 +655,15 @@ func (d *dynamoClient) UpdateTurn1CompletionDetails(
 				"failed to marshal processed markdown ref", true)
 		}
 		update = update.Set(expression.Name("processedTurn1MarkdownRef"), expression.Value(avRef))
+	}
+
+	if conversationRef != nil && conversationRef.Key != "" {
+		avConv, err := attributevalue.MarshalMap(conversationRef)
+		if err != nil {
+			return errors.WrapError(err, errors.ErrorTypeDynamoDB,
+				"failed to marshal conversation ref", true)
+		}
+		update = update.Set(expression.Name("turn1ConversationRef"), expression.Value(avConv))
 	}
 
 	builder := expression.NewBuilder().WithUpdate(update)


### PR DESCRIPTION
## Summary
- capture turn1 conversation messages and save to S3
- include conversation reference in S3 trees and step function output
- update DynamoDB writes with conversation S3 reference

## Testing
- `make test` *(fails: cannot load module)*
- `go vet ./...` *(fails: module missing in go.work)*