### PR TITLE
Implement Turn2 conversation history storage

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.2.5] - 2025-05-30 - Store Turn 2 Conversation
+### Added
+- Stored `turn2-conversation.json` capturing the full conversation after Turn 2.
+- DynamoDB and Step Function output now reference the Turn 2 conversation file.
+
 ## [2.2.4] - 2025-05-29 - Add Turn 2 Prompt Reference
 ### Added
 - Persisted Turn 2 prompt to S3 using `SaveToEnvelope` under `prompts/turn2-prompt.json`.

--- a/product-approach/workflow-function/ExecuteTurn2Combined/cmd/main.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/cmd/main.go
@@ -411,7 +411,7 @@ func HandleRequest(ctx context.Context, event json.RawMessage) (interface{}, err
 	}
 
 	// Execute handler with deterministic architecture
-	response, err := applicationContainer.handler.ProcessTurn2Request(enrichedCtx, &req)
+	response, _, err := applicationContainer.handler.ProcessTurn2Request(enrichedCtx, &req)
 
 	executionContext.ExecutionMetrics.ProcessingDuration = time.Since(executionStartTime)
 

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/dynamo_manager.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/dynamo_manager.go
@@ -27,6 +27,7 @@ type Turn2Result struct {
 	VerificationStatus string
 	Discrepancies      []schema.Discrepancy
 	ComparisonSummary  string
+	ConversationRef    *models.S3Reference
 }
 
 // NewDynamoManager creates a DynamoManager instance.
@@ -94,7 +95,7 @@ func (d *DynamoManager) UpdateTurn2Completion(ctx context.Context, res Turn2Resu
 		dynamoOK = false
 	}
 
-	if err := d.dynamo.UpdateTurn2CompletionDetails(ctx, res.VerificationID, res.VerificationAt, res.StatusEntry, res.Metrics, res.VerificationStatus, res.Discrepancies, res.ComparisonSummary); err != nil {
+	if err := d.dynamo.UpdateTurn2CompletionDetails(ctx, res.VerificationID, res.VerificationAt, res.StatusEntry, res.Metrics, res.VerificationStatus, res.Discrepancies, res.ComparisonSummary, res.ConversationRef); err != nil {
 		d.log.Warn("dynamodb update turn2 completion details failed", map[string]interface{}{
 			"error":     err.Error(),
 			"retryable": errors.IsRetryable(err),

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/handler_helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/handler_helpers.go
@@ -273,13 +273,13 @@ func (h *Turn2Handler) handleStepFunctionEvent(ctx context.Context, req *models.
 
 	h.log.LogReceivedEvent(req)
 
-	turn2Resp, err := h.ProcessTurn2Request(ctx, req)
+	turn2Resp, convRef, err := h.ProcessTurn2Request(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
 	builder := NewResponseBuilder(h.cfg)
-	stepFunctionResponse := builder.BuildTurn2StepFunctionResponse(req, turn2Resp)
+	stepFunctionResponse := builder.BuildTurn2StepFunctionResponse(req, turn2Resp, convRef)
 
 	h.log.LogOutputEvent(stepFunctionResponse)
 
@@ -290,7 +290,7 @@ func (h *Turn2Handler) handleStepFunctionEvent(ctx context.Context, req *models.
 func (h *Turn2Handler) handleDirectRequest(ctx context.Context, req *models.Turn2Request) (interface{}, error) {
 	h.log.LogReceivedEvent(req)
 
-	response, err := h.ProcessTurn2Request(ctx, req)
+	response, _, err := h.ProcessTurn2Request(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/helpers.go
@@ -12,11 +12,12 @@ import (
 
 // S3ReferenceTree represents a complete tree of S3 references for a verification
 type S3ReferenceTree struct {
-	Initialization models.S3Reference   `json:"initialization,omitempty"`
-	Images         ImageReferences      `json:"images,omitempty"`
-	Processing     ProcessingReferences `json:"processing,omitempty"`
-	Prompts        PromptReferences     `json:"prompts,omitempty"`
-	Responses      ResponseReferences   `json:"responses,omitempty"`
+	Initialization models.S3Reference     `json:"initialization,omitempty"`
+	Images         ImageReferences        `json:"images,omitempty"`
+	Processing     ProcessingReferences   `json:"processing,omitempty"`
+	Prompts        PromptReferences       `json:"prompts,omitempty"`
+	Conversation   ConversationReferences `json:"conversation,omitempty"`
+	Responses      ResponseReferences     `json:"responses,omitempty"`
 }
 
 // PromptReferences holds S3 references for prompt artifacts
@@ -37,6 +38,12 @@ type ImageReferences struct {
 type ProcessingReferences struct {
 	HistoricalContext models.S3Reference `json:"historicalContext,omitempty"`
 	LayoutMetadata    models.S3Reference `json:"layoutMetadata,omitempty"`
+}
+
+// ConversationReferences holds references for conversation history
+type ConversationReferences struct {
+	Turn1 models.S3Reference `json:"turn1,omitempty"`
+	Turn2 models.S3Reference `json:"turn2,omitempty"`
 }
 
 // ResponseReferences holds S3 references for response artifacts
@@ -71,7 +78,7 @@ type TokenUsageDetailed struct {
 // buildTurn2S3RefTree constructs a unified S3 reference tree from various sources for Turn2
 func buildTurn2S3RefTree(
 	base models.Turn2RequestS3Refs,
-	promptRef, rawRef, procRef models.S3Reference,
+	promptRef, rawRef, procRef, convRef models.S3Reference,
 ) S3ReferenceTree {
 	// Extract verification ID from the key pattern
 	verificationID := extractVerificationID(rawRef.Key)
@@ -124,6 +131,9 @@ func buildTurn2S3RefTree(
 		},
 		Prompts: PromptReferences{
 			SystemPrompt: base.Prompts.System,
+		},
+		Conversation: ConversationReferences{
+			Turn2: convRef,
 		},
 		Responses: ResponseReferences{
 			Turn2Raw:       rawRef,

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
@@ -142,6 +142,8 @@ type S3StateManager interface {
 	StoreProcessedTurn1Response(ctx context.Context, verificationID string, analysisData *bedrockparser.ParsedTurn1Data) (models.S3Reference, error)
 	StoreProcessedTurn1Markdown(ctx context.Context, verificationID string, markdownContent string) (models.S3Reference, error)
 	StoreConversationTurn(ctx context.Context, verificationID string, turnData *schema.TurnResponse) (models.S3Reference, error)
+	// StoreTurn2Conversation stores full conversation messages for turn2
+	StoreTurn2Conversation(ctx context.Context, verificationID string, messages []map[string]interface{}) (models.S3Reference, error)
 	StoreTemplateProcessor(ctx context.Context, verificationID string, processor *schema.TemplateProcessor) (models.S3Reference, error)
 	StoreProcessingMetrics(ctx context.Context, verificationID string, metrics *schema.ProcessingMetrics) (models.S3Reference, error)
 	LoadProcessingState(ctx context.Context, verificationID string, stateType string) (interface{}, error)

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3_turn2.go
@@ -246,3 +246,27 @@ func (m *s3Manager) StoreTurn2Markdown(ctx context.Context, verificationID strin
 
 	return m.fromStateReference(stateRef), nil
 }
+
+// StoreTurn2Conversation stores full conversation messages for turn2
+func (m *s3Manager) StoreTurn2Conversation(ctx context.Context, verificationID string, messages []map[string]interface{}) (models.S3Reference, error) {
+	if verificationID == "" {
+		return models.S3Reference{}, errors.NewValidationError(
+			"verification ID required for storing turn2 conversation",
+			map[string]interface{}{"operation": "store_turn2_conversation"})
+	}
+
+	key := "responses/turn2-conversation.json"
+	data := map[string]interface{}{
+		"verificationId": verificationID,
+		"turnId":         2,
+		"messages":       messages,
+		"timestamp":      schema.FormatISO8601(),
+	}
+	stateRef, err := m.stateManager.StoreJSON(m.datePath(verificationID), key, data)
+	if err != nil {
+		return models.S3Reference{}, errors.WrapError(err, errors.ErrorTypeS3,
+			"failed to store turn2 conversation", true).
+			WithContext("verification_id", verificationID)
+	}
+	return m.fromStateReference(stateRef), nil
+}


### PR DESCRIPTION
## Summary
- modify existing ExecuteTurn2Combined workflow to save `turn2-conversation.json`
- update DynamoDB and Step Function builders for conversation reference
- remove temporary standalone implementation
- document changes in ExecuteTurn2Combined changelog

## Testing
- `go test ./...` *(fails: module paths missing)*