### PR TITLE
Refactor Turn2 handler for better logging and output formatting

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -993,3 +993,9 @@ For developers working with this codebase:
 ## [0.1.0] - 2025-06-04
 ### Added
 - Initial skeleton implementation.
+
+## [0.1.1] - 2025-06-05
+### Changed
+- Turn2 raw response now stored as `schema.TurnResponse` with comprehensive metadata.
+- Conversation history includes Turn1 messages and correct image formatting.
+- Step Function output expanded to include all input references and new Turn2 artifacts.

--- a/product-approach/workflow-function/ExecuteTurn2Combined/cmd/main.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/cmd/main.go
@@ -411,7 +411,7 @@ func HandleRequest(ctx context.Context, event json.RawMessage) (interface{}, err
 	}
 
 	// Execute handler with deterministic architecture
-	response, _, err := applicationContainer.handler.ProcessTurn2Request(enrichedCtx, &req)
+	response, _, _, err := applicationContainer.handler.ProcessTurn2Request(enrichedCtx, &req)
 
 	executionContext.ExecutionMetrics.ProcessingDuration = time.Since(executionStartTime)
 

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/handler_helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/handler_helpers.go
@@ -273,13 +273,13 @@ func (h *Turn2Handler) handleStepFunctionEvent(ctx context.Context, req *models.
 
 	h.log.LogReceivedEvent(req)
 
-	turn2Resp, convRef, err := h.ProcessTurn2Request(ctx, req)
+	turn2Resp, convRef, promptRef, err := h.ProcessTurn2Request(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
 	builder := NewResponseBuilder(h.cfg)
-	stepFunctionResponse := builder.BuildTurn2StepFunctionResponse(req, turn2Resp, convRef)
+	stepFunctionResponse := builder.BuildTurn2StepFunctionResponse(req, turn2Resp, promptRef, convRef)
 
 	h.log.LogOutputEvent(stepFunctionResponse)
 
@@ -290,7 +290,7 @@ func (h *Turn2Handler) handleStepFunctionEvent(ctx context.Context, req *models.
 func (h *Turn2Handler) handleDirectRequest(ctx context.Context, req *models.Turn2Request) (interface{}, error) {
 	h.log.LogReceivedEvent(req)
 
-	response, _, err := h.ProcessTurn2Request(ctx, req)
+	response, _, _, err := h.ProcessTurn2Request(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/helpers.go
@@ -133,6 +133,7 @@ func buildTurn2S3RefTree(
 			SystemPrompt: base.Prompts.System,
 		},
 		Conversation: ConversationReferences{
+			Turn1: base.Turn1.Conversation,
 			Turn2: convRef,
 		},
 		Responses: ResponseReferences{

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/request.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/request.go
@@ -26,8 +26,9 @@ type Turn2RequestS3Refs struct {
 
 // Turn1References holds S3 locations for Turn-1 artifacts needed for Turn-2.
 type Turn1References struct {
-	ProcessedResponse S3Reference `json:"processedResponse"` // turn1-processed-response.json
-	RawResponse       S3Reference `json:"rawResponse"`       // turn1-raw-response.json
+	ProcessedResponse S3Reference `json:"processedResponse"`      // turn1-processed-response.json
+	RawResponse       S3Reference `json:"rawResponse"`            // turn1-raw-response.json
+	Conversation      S3Reference `json:"conversation,omitempty"` // turn1-conversation.json
 }
 
 // Turn2ImageRefs holds S3 locations for image artifacts for Turn-2.

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
@@ -143,7 +143,7 @@ type S3StateManager interface {
 	StoreProcessedTurn1Markdown(ctx context.Context, verificationID string, markdownContent string) (models.S3Reference, error)
 	StoreConversationTurn(ctx context.Context, verificationID string, turnData *schema.TurnResponse) (models.S3Reference, error)
 	// StoreTurn2Conversation stores full conversation messages for turn2
-	StoreTurn2Conversation(ctx context.Context, verificationID string, messages []map[string]interface{}) (models.S3Reference, error)
+	StoreTurn2Conversation(ctx context.Context, verificationID string, data *Turn2ConversationData) (models.S3Reference, error)
 	StoreTemplateProcessor(ctx context.Context, verificationID string, processor *schema.TemplateProcessor) (models.S3Reference, error)
 	StoreProcessingMetrics(ctx context.Context, verificationID string, metrics *schema.ProcessingMetrics) (models.S3Reference, error)
 	LoadProcessingState(ctx context.Context, verificationID string, stateType string) (interface{}, error)


### PR DESCRIPTION
## Summary
- add conversation reference to Turn2 request models
- store turn2 prompt and build full TurnResponse for raw logging
- load turn1 conversation and compose turn2 conversation history
- store conversation via new `Turn2ConversationData` struct
- expand Step Function output references and update builders
- update CHANGELOG

## Testing
- `go vet ./...` *(fails: module loading issues)*