### PR TITLE
Refactor Turn2 context handling

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.2.7] - 2025-06-10 - Turn 1 Context Integration and Output Fixes
+
+### Added
+- `LoadTurn1SchemaResponse` to `S3StateManager` and implementation in `s3_turn2.go`.
+- `InputS3References` field on `Turn2Request` for carrying event references.
+- New `TurnConversationDataStore` struct for conversation storage.
+
+### Changed
+- `ConverseWithHistory` call chain now accepts `*schema.TurnResponse` to provide full Turn 1 context.
+- Conversation building uses `TurnConversationDataStore` and includes Turn 1 messages.
+- Step Function response builder preserves incoming S3 references and adds Turn 2 artifacts.
+
+### Fixed
+- Raw Turn 2 response now includes Bedrock `requestId` field.
+- Prompt generation and Bedrock invocation pass Turn 1 analysis correctly.
+
 ## [2.2.6] - 2025-05-30 - Critical Schema Compliance and Parser Enhancement
 
 ### 🚨 **Critical Bug Fixes: Output Schema Alignment**

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client_turn2.go
@@ -66,7 +66,7 @@ func NewClientTurn2(cfg config.Config, log logger.Logger) (*ClientTurn2, error) 
 
 // ProcessTurn2 handles the complete Turn2 processing
 // MODIFICATION START: added imageFormat parameter
-func (c *ClientTurn2) ProcessTurn2(ctx context.Context, systemPrompt, turn2Prompt, base64Image, imageFormat string, turn1Response *schema.Turn1ProcessedResponse) (*schema.BedrockResponse, error) {
+func (c *ClientTurn2) ProcessTurn2(ctx context.Context, systemPrompt, turn2Prompt, base64Image, imageFormat string, turn1Response *schema.TurnResponse) (*schema.BedrockResponse, error) {
 	startTime := time.Now()
 
 	// Validate configuration

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/event_transformer.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/event_transformer.go
@@ -362,6 +362,7 @@ func (e *EventTransformer) TransformStepFunctionEvent(ctx context.Context, event
 			},
 		},
 		InputInitializationFileRef: initRef,
+		InputS3References:          event.S3References,
 	}
 
 	// Populate historical context S3 reference for PREVIOUS_VS_CURRENT

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/handler_helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/handler_helpers.go
@@ -92,7 +92,7 @@ type PromptResult struct {
 }
 
 // generateTurn2Prompt generates the Turn2 prompt with Turn1 context
-func (h *Turn2Handler) generateTurn2Prompt(ctx context.Context, req *models.Turn2Request, systemPrompt string, turn1Response *schema.Turn1ProcessedResponse, turn1RawResponse []byte) *PromptResult {
+func (h *Turn2Handler) generateTurn2Prompt(ctx context.Context, req *models.Turn2Request, systemPrompt string, turn1Response *schema.TurnResponse, turn1RawResponse []byte) *PromptResult {
 	startTime := time.Now()
 
 	// Create verification context for Turn2

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/response_builder.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/response_builder.go
@@ -120,16 +120,21 @@ func (r *ResponseBuilder) BuildTurn2StepFunctionResponse(
 ) *models.StepFunctionResponse {
 	tree := buildTurn2S3RefTree(req.S3Refs, promptRef, turn2Resp.S3Refs.RawResponse, turn2Resp.S3Refs.ProcessedResponse, convRef)
 
-	s3References := map[string]interface{}{
-		"processing_initialization": tree.Initialization,
-		"images_metadata":           tree.Images.Metadata,
-		"prompts_system":            tree.Prompts.SystemPrompt,
-		"responses": map[string]interface{}{
-			"turn2Raw":       tree.Responses.Turn2Raw,
-			"turn2Processed": tree.Responses.Turn2Processed,
-			"turn1Raw":       tree.Responses.Turn1Raw,
-			"turn1Processed": tree.Responses.Turn1Processed,
-		},
+	s3References := map[string]interface{}{}
+	// carry over all input references first
+	for k, v := range req.InputS3References {
+		s3References[k] = v
+	}
+
+	// overwrite / add updated turn2 references
+	s3References["prompts_system"] = tree.Prompts.SystemPrompt
+	s3References["processing_initialization"] = tree.Initialization
+	s3References["images_metadata"] = tree.Images.Metadata
+	s3References["responses"] = map[string]interface{}{
+		"turn2Raw":       tree.Responses.Turn2Raw,
+		"turn2Processed": tree.Responses.Turn2Processed,
+		"turn1Raw":       tree.Responses.Turn1Raw,
+		"turn1Processed": tree.Responses.Turn1Processed,
 	}
 
 	if tree.Prompts.Turn1Prompt.Key != "" {

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/request.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/request.go
@@ -10,6 +10,9 @@ type Turn2Request struct {
 	VerificationID      string              `json:"verificationId"`
 	VerificationContext VerificationContext `json:"verificationContext"`
 	S3Refs              Turn2RequestS3Refs  `json:"s3References"`
+	// InputS3References preserves all incoming S3 references from the Step
+	// Function event so they can be carried over to the output state
+	InputS3References map[string]interface{} `json:"-"`
 	// InputInitializationFileRef stores the S3 location of the initialization.json
 	// that was used to create this request. It is not part of the incoming
 	// JSON payload but is populated internally for status updates.

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/bedrock_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/bedrock_turn2.go
@@ -14,8 +14,7 @@ type BedrockServiceTurn2 interface {
 	BedrockService
 
 	// ConverseWithHistory handles Turn2 conversation with history from Turn1
-	// MODIFICATION START: added imageFormat parameter
-	ConverseWithHistory(ctx context.Context, systemPrompt, turn2Prompt, base64Image, imageFormat string, turn1Response *schema.Turn1ProcessedResponse) (*schema.BedrockResponse, error)
+	ConverseWithHistory(ctx context.Context, systemPrompt, turn2Prompt, base64Image, imageFormat string, turn1Response *schema.TurnResponse) (*schema.BedrockResponse, error)
 	// MODIFICATION END
 }
 
@@ -46,6 +45,6 @@ func NewBedrockServiceTurn2(cfg config.Config, log logger.Logger) (BedrockServic
 }
 
 // ConverseWithHistory handles Turn2 conversation with history from Turn1
-func (s *bedrockServiceTurn2) ConverseWithHistory(ctx context.Context, systemPrompt, turn2Prompt, base64Image, imageFormat string, turn1Response *schema.Turn1ProcessedResponse) (*schema.BedrockResponse, error) {
+func (s *bedrockServiceTurn2) ConverseWithHistory(ctx context.Context, systemPrompt, turn2Prompt, base64Image, imageFormat string, turn1Response *schema.TurnResponse) (*schema.BedrockResponse, error) {
 	return s.clientTurn2.ProcessTurn2(ctx, systemPrompt, turn2Prompt, base64Image, imageFormat, turn1Response)
 }

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/prompt_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/prompt_turn2.go
@@ -15,7 +15,7 @@ import (
 
 // PromptServiceTurn2 defines Turn2 prompt generation service
 type PromptServiceTurn2 interface {
-	GenerateTurn2PromptWithMetrics(ctx context.Context, vCtx *schema.VerificationContext, systemPrompt string, turn1Response *schema.Turn1ProcessedResponse, turn1RawResponse json.RawMessage) (string, *schema.TemplateProcessor, error)
+	GenerateTurn2PromptWithMetrics(ctx context.Context, vCtx *schema.VerificationContext, systemPrompt string, turn1Response *schema.TurnResponse, turn1RawResponse json.RawMessage) (string, *schema.TemplateProcessor, error)
 }
 
 // promptServiceTurn2 implements PromptServiceTurn2
@@ -45,7 +45,7 @@ func NewPromptServiceTurn2(loader templateloader.TemplateLoader, cfg *config.Con
 }
 
 // GenerateTurn2PromptWithMetrics renders the Turn2 prompt and returns metrics
-func (p *promptServiceTurn2) GenerateTurn2PromptWithMetrics(ctx context.Context, vCtx *schema.VerificationContext, systemPrompt string, turn1Response *schema.Turn1ProcessedResponse, turn1RawResponse json.RawMessage) (string, *schema.TemplateProcessor, error) {
+func (p *promptServiceTurn2) GenerateTurn2PromptWithMetrics(ctx context.Context, vCtx *schema.VerificationContext, systemPrompt string, turn1Response *schema.TurnResponse, turn1RawResponse json.RawMessage) (string, *schema.TemplateProcessor, error) {
 	start := time.Now()
 	if vCtx == nil {
 		return "", nil, errors.NewValidationError("verification context required", nil)

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
@@ -143,7 +143,7 @@ type S3StateManager interface {
 	StoreProcessedTurn1Markdown(ctx context.Context, verificationID string, markdownContent string) (models.S3Reference, error)
 	StoreConversationTurn(ctx context.Context, verificationID string, turnData *schema.TurnResponse) (models.S3Reference, error)
 	// StoreTurn2Conversation stores full conversation messages for turn2
-	StoreTurn2Conversation(ctx context.Context, verificationID string, data *Turn2ConversationData) (models.S3Reference, error)
+	StoreTurn2Conversation(ctx context.Context, verificationID string, data *TurnConversationDataStore) (models.S3Reference, error)
 	StoreTemplateProcessor(ctx context.Context, verificationID string, processor *schema.TemplateProcessor) (models.S3Reference, error)
 	StoreProcessingMetrics(ctx context.Context, verificationID string, metrics *schema.ProcessingMetrics) (models.S3Reference, error)
 	LoadProcessingState(ctx context.Context, verificationID string, stateType string) (interface{}, error)
@@ -151,6 +151,8 @@ type S3StateManager interface {
 	// Turn1 specific loaders used by ExecuteTurn2Combined
 	LoadTurn1ProcessedResponse(ctx context.Context, ref models.S3Reference) (*schema.Turn1ProcessedResponse, error)
 	LoadTurn1RawResponse(ctx context.Context, ref models.S3Reference) (json.RawMessage, error)
+	// LoadTurn1SchemaResponse loads the raw Turn1 response into schema.TurnResponse
+	LoadTurn1SchemaResponse(ctx context.Context, ref models.S3Reference) (*schema.TurnResponse, error)
 
 	// Turn2 specific storage helpers
 	StoreTurn2Response(ctx context.Context, verificationID string, response *bedrockparser.ParsedTurn2Data) (models.S3Reference, error)


### PR DESCRIPTION
## Summary
- load Turn1 raw response and pass to Bedrock
- preserve incoming S3 references in Turn2 request and output
- store conversation using new TurnConversationDataStore
- include Bedrock requestId in raw response
- update changelog

## Testing
- `go build ./...` *(fails: no such go modules)*