### PR TITLE
Fix Turn2 raw response storage and merge conversation history

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter_turn2.go
@@ -93,90 +93,53 @@ func (a *AdapterTurn2) ConverseWithHistory(ctx context.Context, systemPrompt, tu
 		"operation":         "bedrock_converse_with_history",
 	})
 
-	// NOTE: As of version 2.1.2, Turn1 dependencies were removed from Turn2 processing
-	// Turn1 message is no longer used in Turn2 processing, but we handle it gracefully
-	turn1Message := ""
-
-	// Handle nil Turn1Response gracefully - this is expected as of v2.1.2
+	turn1Size := 0
 	if turn1Response != nil {
-		a.log.Debug("turn1_response_present", map[string]interface{}{
-			"operation": "bedrock_converse_with_history",
-		})
-
-		// Extract content from the response directly
-		if turn1Response.Response.Content != "" {
-			turn1Message += turn1Response.Response.Content
-		}
-	} else {
-		a.log.Debug("turn1_response_nil", map[string]interface{}{
-			"operation": "bedrock_converse_with_history",
-			"message":   "This is expected as of v2.1.2 which removed Turn1 dependencies",
-		})
+		turn1Size = len(turn1Response.Prompt) + len(turn1Response.Response.Content)
 	}
-	// No default message when turn1Response is nil - Turn1 is not used in Turn2 processing
 
-	// Build request with conversation history using the correct types
-	// Initialize messages array with first user message
+	// Build conversation beginning with a single system prompt
 	messages := []sharedBedrock.MessageWrapper{
 		{
-			Role: "user",
-			Content: []sharedBedrock.ContentBlock{
-				{
-					Type: "text",
-					Text: "[Turn 1] Please analyze this image.",
-				},
-			},
+			Role:    "system",
+			Content: []sharedBedrock.ContentBlock{{Type: "text", Text: systemPrompt}},
 		},
 	}
 
-	// Only add assistant message if turn1Message has content to prevent empty text blocks
-	if strings.TrimSpace(turn1Message) != "" {
-		messages = append(messages, sharedBedrock.MessageWrapper{
-			Role: "assistant",
-			Content: []sharedBedrock.ContentBlock{
-				{
-					Type: "text",
-					Text: turn1Message,
-				},
-			},
-		})
-		a.log.Debug("turn1_message_included", map[string]interface{}{
-			"operation":            "bedrock_converse_with_history",
-			"turn1_message_length": len(turn1Message),
-		})
-	} else {
-		a.log.Debug("turn1_message_skipped", map[string]interface{}{
-			"operation": "bedrock_converse_with_history",
-			"reason":    "empty or whitespace-only content",
-		})
+	// Include Turn 1 user and assistant messages when provided
+	if turn1Response != nil {
+		if strings.TrimSpace(turn1Response.Prompt) != "" {
+			messages = append(messages, sharedBedrock.MessageWrapper{
+				Role:    "user",
+				Content: []sharedBedrock.ContentBlock{{Type: "text", Text: turn1Response.Prompt}},
+			})
+		}
+		if strings.TrimSpace(turn1Response.Response.Content) != "" {
+			messages = append(messages, sharedBedrock.MessageWrapper{
+				Role:    "assistant",
+				Content: []sharedBedrock.ContentBlock{{Type: "text", Text: turn1Response.Response.Content}},
+			})
+		}
 	}
 
 	// Add final user message with Turn 2 prompt and image
 	messages = append(messages, sharedBedrock.MessageWrapper{
 		Role: "user",
 		Content: []sharedBedrock.ContentBlock{
-			{
-				Type: "text",
-				Text: "[Turn 2] " + turn2Prompt,
-			},
+			{Type: "text", Text: turn2Prompt},
 			{
 				Type: "image",
-				// MODIFICATION START: use dynamic image format
 				Image: &sharedBedrock.ImageBlock{
 					Format: format,
-					Source: sharedBedrock.ImageSource{
-						Type:  "bytes",
-						Bytes: base64Image,
-					},
+					Source: sharedBedrock.ImageSource{Type: "bytes", Bytes: base64Image},
 				},
-				// MODIFICATION END
 			},
 		},
 	})
 
 	request := &sharedBedrock.ConverseRequest{
 		ModelId:  a.cfg.AWS.BedrockModel,
-		System:   systemPrompt,
+		System:   "",
 		Messages: messages,
 		InferenceConfig: sharedBedrock.InferenceConfig{
 			MaxTokens:   a.cfg.Processing.MaxTokens,
@@ -209,7 +172,7 @@ func (a *AdapterTurn2) ConverseWithHistory(ctx context.Context, systemPrompt, tu
 		"max_tokens":         a.cfg.Processing.MaxTokens,
 		"system_prompt_size": len(systemPrompt),
 		"turn2_prompt_size":  len(turn2Prompt),
-		"turn1_message_size": len(turn1Message),
+		"turn1_message_size": turn1Size,
 		"image_size":         len(base64Image),
 		"image_format":       format,
 		"message_count":      len(request.Messages),

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/storage_manager.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/storage_manager.go
@@ -23,13 +23,13 @@ func NewStorageManager(manager s3state.Manager, log logger.Logger) *StorageManag
 // SaveTurn2Outputs stores the raw Bedrock response and the processed analysis
 // into the provided envelope. The references are also mapped to concise keys
 // (turn2Raw and turn2Processed) for downstream use.
-func (s *StorageManager) SaveTurn2Outputs(ctx context.Context, envelope *s3state.Envelope, raw []byte, processed interface{}) (models.S3Reference, models.S3Reference, error) {
+func (s *StorageManager) SaveTurn2Outputs(ctx context.Context, envelope *s3state.Envelope, raw interface{}, processed interface{}) (models.S3Reference, models.S3Reference, error) {
 	if envelope == nil {
 		return models.S3Reference{}, models.S3Reference{}, nil
 	}
 
-	// Save raw bytes
-	if err := s.manager.SaveToEnvelope(envelope, "responses", "turn2-raw-response.json", json.RawMessage(raw)); err != nil {
+	// Save raw structure directly so JSON is preserved
+	if err := s.manager.SaveToEnvelope(envelope, "responses", "turn2-raw-response.json", raw); err != nil {
 		return models.S3Reference{}, models.S3Reference{}, err
 	}
 	rawRef := envelope.GetReference("responses_turn2-raw-response")

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/storage_manager_test.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/storage_manager_test.go
@@ -34,7 +34,7 @@ func TestSaveTurn2Outputs(t *testing.T) {
 	mgr := &stubS3Manager{}
 	sm := NewStorageManager(mgr, logger.New("test", "test"))
 
-	raw := []byte("{}")
+	raw := map[string]string{"foo": "bar"}
 	proc := map[string]string{"a": "b"}
 
 	rawRef, procRef, err := sm.SaveTurn2Outputs(context.Background(), env, raw, proc)


### PR DESCRIPTION
## Summary
- store Turn2 raw responses as JSON objects
- update storage manager to accept structured raw data
- skip duplicate system prompts when building conversation history
- merge Turn1 messages into Turn2 Bedrock request
- adjust unit tests for new storage behavior

## Testing
- `go test ./...` *(fails: cannot load modules)*

------
https://chatgpt.com/codex/tasks/task_b_683ab06e7bac832d86222555d25eb48f