### PR TITLE
Fix Turn2 raw response storage and conversation context

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.2.8] - 2025-06-12 - Bedrock Conversation Fixes
+
+### Fixed
+- `turn2-raw-response.json` now stores plain JSON instead of base64 encoded data.
+- Conversation history no longer duplicates the system prompt.
+- Bedrock request for Turn 2 reuses Turn 1 user prompt and assistant response for proper context.
+
+
 ## [2.2.7] - 2025-06-10 - Turn 1 Context Integration and Output Fixes
 
 ### Added


### PR DESCRIPTION
## Summary
- avoid base64 when saving Turn2 raw response
- prevent duplicate system prompt when building conversation history
- include Turn1 context in Bedrock request
- document fixes in changelog

## Testing
- `go build ./...` *(fails: go.work references missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_683abada2950832dbd520b8315644950