### PR TITLE
Fix Step Function response handling

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.2.10] - 2025-08-20 - Step Function Response Fix
+
+### Fixed
+- `HandleRequest` now delegates Step Function invocations to `handler.HandleForStepFunction`.
+- Ensures returned `StepFunctionResponse` preserves incoming S3 references, adds new Turn 2 artifacts, and includes the `verificationId` at the root.
+- **File**: `ExecuteTurn2Combined/cmd/main.go`.
+
 ## [2.2.9] - 2025-08-15 - Bedrock Request and Logging Fixes
 
 ### Fixed


### PR DESCRIPTION
## Summary
- ensure Step Function events use `HandleForStepFunction` so that full `StepFunctionResponse` is returned
- document fix in CHANGELOG

## Testing
- `gofmt -w cmd/main.go`
- `GOWORK=off go vet ./...` *(fails: proxyconnect tcp: no route to host)*
- `GOWORK=off go test ./...` *(fails: proxyconnect tcp: no route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683ad0515990832d84129a6e4efc2fa6