### PR TITLE
Fix Turn1 reference parsing in ExecuteTurn2Combined

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/event_transformer.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/event_transformer.go
@@ -289,12 +289,12 @@ func (e *EventTransformer) TransformStepFunctionEvent(ctx context.Context, event
 		// Convert interface{} to map for nested access
 		if responsesData, ok := responsesMap.(map[string]interface{}); ok {
 			if turn1Proc, exists := responsesData["turn1Processed"]; exists {
-				if procRef, ok := turn1Proc.(models.S3Reference); ok {
+				if procRef, ok := convertToS3Reference(turn1Proc); ok {
 					turn1ProcessedRef = procRef
 				}
 			}
 			if turn1Raw, exists := responsesData["turn1Raw"]; exists {
-				if rawRef, ok := turn1Raw.(models.S3Reference); ok {
+				if rawRef, ok := convertToS3Reference(turn1Raw); ok {
 					turn1RawRef = rawRef
 				}
 			}


### PR DESCRIPTION
## Summary
- correct parsing of nested `turn1Raw` and `turn1Processed` references

## Testing
- `go build ./product-approach/workflow-function/ExecuteTurn2Combined/cmd` *(fails: module path issue)*

------
https://chatgpt.com/codex/tasks/task_b_683ad3816c90832d84787b3bc5259671