### PR TITLE
Enhance thinking block storage

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -96,6 +96,13 @@ All notable changes to the ExecuteTurn1Combined function will be documented in t
 - **Storage Layer**: S3 conversation files enhanced with thinking content structure
 - **Response Processing**: Complete thinking content extraction and metadata handling
 
+## [2.5.2] - 2025-06-04
+### Changed
+- `turn1-conversation.json` now includes a top-level `thinkingBlocks` array when available.
+- The raw thinking content string is omitted from the assistant message when `thinkingBlocks` are stored.
+- Updated storage logic in `StoreTurn1Conversation` and `buildAssistantContent` to support this behavior.
+- Calls to `StoreConversation` now pass Bedrock response metadata for thinking block extraction.
+
 ## [2.5.1] - 2025-05-30
 ### Fixed
 - **Schema Compliance for turn1-conversation.json**: Fixed turn1-conversation.json structure to match defined schema requirements

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/handler.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/handler.go
@@ -180,7 +180,7 @@ func (h *Handler) Handle(ctx context.Context, req *models.Turn1Request) (resp *s
 		return nil, storageResult.Error
 	}
 	h.recordStorageSuccess(storageResult)
-	
+
 	// Extract thinking content if available
 	var thinkingContent string
 	if invokeResult.Response.Metadata != nil {
@@ -188,9 +188,9 @@ func (h *Handler) Handle(ctx context.Context, req *models.Turn1Request) (resp *s
 			thinkingContent = thinking
 		}
 	}
-	
+
 	// Store conversation with complete schema compliance
-	convRef, convErr := h.storageManager.StoreConversation(ctx, req.VerificationID, loadResult.SystemPrompt, promptResult.Prompt, loadResult.Base64Image, bedrockTextOutput, thinkingContent, &invokeResult.Response.TokenUsage, invokeResult.Duration.Milliseconds(), invokeResult.Response.RequestID, h.cfg.AWS.BedrockModel)
+	convRef, convErr := h.storageManager.StoreConversation(ctx, req.VerificationID, loadResult.SystemPrompt, promptResult.Prompt, loadResult.Base64Image, bedrockTextOutput, thinkingContent, &invokeResult.Response.TokenUsage, invokeResult.Duration.Milliseconds(), invokeResult.Response.RequestID, h.cfg.AWS.BedrockModel, invokeResult.Response.Metadata)
 	if convErr != nil {
 		h.log.Warn("failed to store conversation", map[string]interface{}{
 			"error": convErr.Error(),
@@ -383,7 +383,7 @@ func (h *Handler) HandleForStepFunction(ctx context.Context, req *models.Turn1Re
 	}
 
 	// Store conversation with complete schema compliance
-	convRef, convErr := h.storageManager.StoreConversation(ctx, req.VerificationID, loadResult.SystemPrompt, promptResult.Prompt, loadResult.Base64Image, bedrockTextOutput, thinkingContent, &invokeResult.Response.TokenUsage, invokeResult.Duration.Milliseconds(), invokeResult.Response.RequestID, h.cfg.AWS.BedrockModel)
+	convRef, convErr := h.storageManager.StoreConversation(ctx, req.VerificationID, loadResult.SystemPrompt, promptResult.Prompt, loadResult.Base64Image, bedrockTextOutput, thinkingContent, &invokeResult.Response.TokenUsage, invokeResult.Duration.Milliseconds(), invokeResult.Response.RequestID, h.cfg.AWS.BedrockModel, invokeResult.Response.Metadata)
 	if convErr != nil {
 		return nil, convErr
 	}
@@ -448,13 +448,13 @@ func (h *Handler) HandleForStepFunction(ctx context.Context, req *models.Turn1Re
 	}
 
 	// Store conversation with complete schema compliance (second call for step function)
-	convRef, convErr = h.storageManager.StoreConversation(ctx, req.VerificationID, loadResult.SystemPrompt, promptResult.Prompt, loadResult.Base64Image, bedrockTextOutput, thinkingContent, &invokeResult.Response.TokenUsage, invokeResult.Duration.Milliseconds(), invokeResult.Response.RequestID, h.cfg.AWS.BedrockModel)
+	convRef, convErr = h.storageManager.StoreConversation(ctx, req.VerificationID, loadResult.SystemPrompt, promptResult.Prompt, loadResult.Base64Image, bedrockTextOutput, thinkingContent, &invokeResult.Response.TokenUsage, invokeResult.Duration.Milliseconds(), invokeResult.Response.RequestID, h.cfg.AWS.BedrockModel, invokeResult.Response.Metadata)
 	if convErr != nil {
 		h.log.Warn("failed to store conversation", map[string]interface{}{
 			"error": convErr.Error(),
 		})
 	}
-	
+
 	dynamoOK := h.dynamoManager.UpdateTurn1Completion(ctx, req.VerificationID, req.VerificationContext.VerificationAt, statusEntry, turnEntry, turn1MetricsForDB, &storageResult.ProcessedRef, &convRef)
 
 	// Final status update


### PR DESCRIPTION
## Summary
- support structured thinking blocks in `StoreTurn1Conversation`
- stop writing raw thinking content when structured blocks are stored
- plumb Bedrock metadata through handler to storage layer
- update changelog

## Testing
- `go vet ./...` *(fails: no route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683c14ee6130832dbba8b6962981f3c6