### PR TITLE
Use IfNotExists for status history updates

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/dynamodb.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/dynamodb.go
@@ -635,7 +635,10 @@ func (d *dynamoClient) UpdateTurn1CompletionDetails(
 
 	update := expression.Set(expression.Name("currentStatus"), expression.Value(statusEntry.Status)).
 		Set(expression.Name("lastUpdatedAt"), expression.Value(statusEntry.Timestamp)).
-		Set(expression.Name("statusHistory"), expression.ListAppend(expression.Name("statusHistory"), expression.Value([]types.AttributeValue{&types.AttributeValueMemberM{Value: avStatusEntry}})))
+		Set(expression.Name("statusHistory"), expression.ListAppend(
+			expression.IfNotExists(expression.Name("statusHistory"), expression.Value([]types.AttributeValue{})),
+			expression.Value([]types.AttributeValue{&types.AttributeValueMemberM{Value: avStatusEntry}}),
+		))
 
 	if turn1Metrics != nil {
 		avMetrics, err := attributevalue.MarshalMap(turn1Metrics)

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go
@@ -637,7 +637,10 @@ func (d *dynamoClient) UpdateTurn1CompletionDetails(
 
 	update := expression.Set(expression.Name("currentStatus"), expression.Value(statusEntry.Status)).
 		Set(expression.Name("lastUpdatedAt"), expression.Value(statusEntry.Timestamp)).
-		Set(expression.Name("statusHistory"), expression.ListAppend(expression.Name("statusHistory"), expression.Value([]types.AttributeValue{&types.AttributeValueMemberM{Value: avStatusEntry}})))
+		Set(expression.Name("statusHistory"), expression.ListAppend(
+			expression.IfNotExists(expression.Name("statusHistory"), expression.Value([]types.AttributeValue{})),
+			expression.Value([]types.AttributeValue{&types.AttributeValueMemberM{Value: avStatusEntry}}),
+		))
 
 	if turn1Metrics != nil {
 		avMetrics, err := attributevalue.MarshalMap(turn1Metrics)


### PR DESCRIPTION
## Summary
- ensure `statusHistory` list is created when it doesn't exist during Turn1 completion updates
- apply same logic to ExecuteTurn2Combined

## Testing
- `go test ./...` *(fails: go: cannot load module product-approach/workflow-function/ExecuteTurn1 listed in go.work file: open product-approach/workflow-function/ExecuteTurn1/go.mod: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_683c6ff68198832da47428870ef671b9