### PR TITLE
Track thinking tokens in Turn2 metrics

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/handler_helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/handler_helpers.go
@@ -239,9 +239,10 @@ func (h *Turn2Handler) validateAndLogCompletion(response *models.Turn2Response, 
 			AnalysisStage:    models.StageProcessing,
 			ProcessingTimeMs: totalDuration.Milliseconds(),
 			TokenUsage: models.TokenUsage{
-				InputTokens:  bedrockResp.InputTokens,
-				OutputTokens: bedrockResp.OutputTokens,
-				TotalTokens:  bedrockResp.InputTokens + bedrockResp.OutputTokens,
+				InputTokens:    bedrockResp.InputTokens,
+				OutputTokens:   bedrockResp.OutputTokens,
+				ThinkingTokens: bedrockResp.ThinkingTokens,
+				TotalTokens:    bedrockResp.InputTokens + bedrockResp.OutputTokens + bedrockResp.ThinkingTokens,
 			},
 			BedrockRequestID: "", // RequestID not available in BedrockResponse
 		},

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/helpers.go
@@ -206,8 +206,8 @@ func buildTurn2Summary(
 	tokenUsage := TokenUsageDetailed{
 		Input:    invoke.InputTokens,
 		Output:   invoke.OutputTokens,
-		Thinking: 0, // ThinkingTokens not available in schema.BedrockResponse
-		Total:    invoke.InputTokens + invoke.OutputTokens,
+		Thinking: invoke.ThinkingTokens,
+		Total:    invoke.TotalTokens,
 	}
 
 	// Default to true for conversation tracked and S3 storage completed

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/response_builder.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/response_builder.go
@@ -44,9 +44,10 @@ func (r *ResponseBuilder) BuildCombinedTurn2Response(
 		},
 		LatencyMs: totalDurationMs,
 		TokenUsage: &schema.TokenUsage{
-			InputTokens:  invoke.InputTokens,
-			OutputTokens: invoke.OutputTokens,
-			TotalTokens:  invoke.InputTokens + invoke.OutputTokens,
+			InputTokens:    invoke.InputTokens,
+			OutputTokens:   invoke.OutputTokens,
+			ThinkingTokens: invoke.ThinkingTokens,
+			TotalTokens:    invoke.TotalTokens,
 		},
 		Stage: "COMPARISON_ANALYSIS",
 		Metadata: map[string]interface{}{
@@ -167,9 +168,10 @@ func (r *ResponseBuilder) BuildTurn2StepFunctionResponse(
 		"processingTimeMs":    turn2Resp.Summary.ProcessingTimeMs,
 		"verificationOutcome": turn2Resp.VerificationOutcome,
 		"tokenUsage": map[string]interface{}{
-			"input":  turn2Resp.Summary.TokenUsage.InputTokens,
-			"output": turn2Resp.Summary.TokenUsage.OutputTokens,
-			"total":  turn2Resp.Summary.TokenUsage.TotalTokens,
+			"input":    turn2Resp.Summary.TokenUsage.InputTokens,
+			"output":   turn2Resp.Summary.TokenUsage.OutputTokens,
+			"thinking": turn2Resp.Summary.TokenUsage.ThinkingTokens,
+			"total":    turn2Resp.Summary.TokenUsage.TotalTokens,
 		},
 		"bedrockRequestId": turn2Resp.Summary.BedrockRequestID,
 	}


### PR DESCRIPTION
## Summary
- include thinking tokens when building Turn2 processing metrics
- propagate thinking token counts in Turn2 response summaries
- log thinking tokens for completed Turn2 processing

## Testing
- `go test ./...` *(fails: cannot load modules)*

------
https://chatgpt.com/codex/tasks/task_b_683c77228e2c832db869ab06fbf78619