### PR TITLE
Add thinking support to Turn2 conversation storage

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
@@ -142,8 +142,8 @@ type S3StateManager interface {
 	StoreProcessedTurn1Response(ctx context.Context, verificationID string, analysisData *bedrockparser.ParsedTurn1Data) (models.S3Reference, error)
 	StoreProcessedTurn1Markdown(ctx context.Context, verificationID string, markdownContent string) (models.S3Reference, error)
 	StoreConversationTurn(ctx context.Context, verificationID string, turnData *schema.TurnResponse) (models.S3Reference, error)
-	// StoreTurn2Conversation stores full conversation messages for turn2
-	StoreTurn2Conversation(ctx context.Context, verificationID string, data *TurnConversationDataStore) (models.S3Reference, error)
+       // StoreTurn2Conversation builds and stores full conversation messages for turn2
+       StoreTurn2Conversation(ctx context.Context, verificationID string, turn1Messages []schema.BedrockMessage, systemPrompt string, userPrompt string, base64Image string, assistantResponse string, thinkingContent string, thinkingBlocks []interface{}, tokenUsage *schema.TokenUsage, latencyMs int64, bedrockRequestId string, modelId string, bedrockResponseMetadata map[string]interface{}) (models.S3Reference, error)
 	StoreTemplateProcessor(ctx context.Context, verificationID string, processor *schema.TemplateProcessor) (models.S3Reference, error)
 	StoreProcessingMetrics(ctx context.Context, verificationID string, metrics *schema.ProcessingMetrics) (models.S3Reference, error)
 	LoadProcessingState(ctx context.Context, verificationID string, stateType string) (interface{}, error)


### PR DESCRIPTION
## Summary
- extend `TurnConversationDataStore` with `thinkingBlocks`
- replicate `buildAssistantContent` helper and add `bedrockMessageToMap`
- rebuild `StoreTurn2Conversation` to include thinking fields and latency metadata
- update handler to use new store method signature
- update S3 manager interface

## Testing
- `go mod tidy` *(fails: no route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683c771d1d54832d9032dda5b1d6c202