### PR TITLE
Enable thinking mode for ExecuteTurn2Combined

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter_turn2.go
@@ -154,6 +154,38 @@ func (a *AdapterTurn2) ConverseWithHistory(ctx context.Context, systemPrompt, tu
 		},
 	}
 
+	// Add thinking/reasoning configuration if enabled
+	if a.cfg.IsThinkingEnabled() {
+		request.Reasoning = "enable"
+		request.InferenceConfig.Reasoning = "enable"
+		request.Thinking = map[string]interface{}{
+			"type":          "enabled",
+			"budget_tokens": a.cfg.Processing.BudgetTokens,
+		}
+		a.log.Info("THINKING_ADAPTER_ENABLED", map[string]interface{}{
+			"thinking_type":       a.cfg.Processing.ThinkingType,
+			"budget_tokens":       a.cfg.Processing.BudgetTokens,
+			"request_reasoning":   request.Reasoning,
+			"inference_reasoning": request.InferenceConfig.Reasoning,
+			"request_thinking":    request.Thinking,
+		})
+	} else {
+		a.log.Info("THINKING_ADAPTER_DISABLED", map[string]interface{}{
+			"thinking_type":       a.cfg.Processing.ThinkingType,
+			"request_reasoning":   request.Reasoning,
+			"inference_reasoning": request.InferenceConfig.Reasoning,
+		})
+	}
+
+	// Log the complete request structure for debugging
+	a.log.Info("THINKING_REQUEST_STRUCTURE", map[string]interface{}{
+		"model_id":            request.ModelId,
+		"reasoning_field":     request.Reasoning,
+		"inference_reasoning": request.InferenceConfig.Reasoning,
+		"thinking_field":      request.Thinking,
+		"max_tokens":          request.InferenceConfig.MaxTokens,
+	})
+
 	// Validate request before sending to Bedrock
 	if err := sharedBedrock.ValidateConverseRequest(request); err != nil {
 		a.log.Error("bedrock_request_validation_failed", map[string]interface{}{

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
@@ -132,3 +132,10 @@ func (c *Config) DatePartitionFromTimestamp(ts string) (string, error) {
 	t = t.In(loc)
 	return fmt.Sprintf("%04d/%02d/%02d", t.Year(), t.Month(), t.Day()), nil
 }
+
+// IsThinkingEnabled returns true if thinking/reasoning mode is enabled
+// Thinking is enabled only when THINKING_TYPE is explicitly set to "enable"
+// Thinking is disabled when THINKING_TYPE is "disable" or unset (empty string)
+func (c *Config) IsThinkingEnabled() bool {
+	return c.Processing.ThinkingType == "enable"
+}


### PR DESCRIPTION
## Summary
- expose IsThinkingEnabled helper in ExecuteTurn2Combined config
- support thinking mode in ExecuteTurn2Combined adapter_turn2

## Testing
- `go test ./...` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_683c78487d38832d848b4739cde94cfc