### PR TITLE
Update changelogs for extended thinking support

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the ExecuteTurn1Combined function will be documented in this file.
 
+## [2.8.1] - 2025-06-01 - Extended Thinking Integration
+### Added
+- Unified reasoning configuration across service, adapter, and shared Bedrock client.
+- Captures thinking tokens from responses and stores them with conversation history.
+- Conversation files now include structured thinking blocks when available.
 ## [2.8.0] - 2025-06-01
 ### Fixed - Critical Thinking Blocks Implementation
 - **Root Cause**: Shared Bedrock client was not actually setting reasoning configuration in API requests

--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.2.13] - 2025-06-01 - Extended Thinking Support
+### Added
+- Reasoning configuration applied to Bedrock requests when `THINKING_TYPE=enable`.
+- Captures thinking tokens from Bedrock responses and tracks them in token usage.
+- Conversation history stored with extracted thinking content and blocks.
 ## [2.2.12] - 2025-05-31 - Turn2 Prompt JSON Structure Fix
 
 ### Fixed


### PR DESCRIPTION
## Summary
- document extended thinking integration in ExecuteTurn1Combined
- add changelog entry for ExecuteTurn2Combined extended thinking features

## Testing
- `go test ./...` *(fails: cannot load module)*

------
https://chatgpt.com/codex/tasks/task_b_683c784fd10c832d96ff17e39b66bf5b