### PR TITLE
Fix BedrockResponse struct

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.2.14] - 2025-06-02 - BedrockResponse Struct Update
+### Fixed
+- Added missing fields to `BedrockResponse` in shared schema to resolve compilation errors.
+
 ## [2.2.13] - 2025-06-01 - Extended Thinking Support
 ### Added
 - Reasoning configuration applied to Bedrock requests when `THINKING_TYPE=enable`.

--- a/product-approach/workflow-function/shared/schema/turn1_response.go
+++ b/product-approach/workflow-function/shared/schema/turn1_response.go
@@ -6,26 +6,31 @@ type Turn1ProcessedResponse struct {
 	InitialConfirmation string `json:"initialConfirmation"`
 	MachineStructure    string `json:"machineStructure"`
 	ReferenceRowStatus  string `json:"referenceRowStatus"`
-	
+
 	// Additional fields that might be present in Turn1 responses
-	ProductAnalysis     map[string]interface{} `json:"productAnalysis,omitempty"`
-	LayoutValidation    map[string]interface{} `json:"layoutValidation,omitempty"`
-	QualityAssessment   map[string]interface{} `json:"qualityAssessment,omitempty"`
-	ProcessingMetadata  map[string]interface{} `json:"processingMetadata,omitempty"`
+	ProductAnalysis    map[string]interface{} `json:"productAnalysis,omitempty"`
+	LayoutValidation   map[string]interface{} `json:"layoutValidation,omitempty"`
+	QualityAssessment  map[string]interface{} `json:"qualityAssessment,omitempty"`
+	ProcessingMetadata map[string]interface{} `json:"processingMetadata,omitempty"`
 }
 
 // BedrockResponse represents a standardized response from Bedrock
 type BedrockResponse struct {
-	Content          string        `json:"content"`
-	CompletionReason string        `json:"completionReason"`
-	InputTokens      int           `json:"inputTokens"`
-	OutputTokens     int           `json:"outputTokens"`
-	LatencyMs        int64         `json:"latencyMs"`
-	ModelId          string        `json:"modelId"`
-	Timestamp        string        `json:"timestamp"`
-	Turn             int           `json:"turn,omitempty"`
-	ProcessingTimeMs int64         `json:"processingTimeMs,omitempty"`
-	ModelConfig      *ModelConfig  `json:"modelConfig,omitempty"`
+	Content          string                 `json:"content"`
+	Thinking         string                 `json:"thinking,omitempty"`
+	CompletionReason string                 `json:"completionReason"`
+	InputTokens      int                    `json:"inputTokens"`
+	OutputTokens     int                    `json:"outputTokens"`
+	ThinkingTokens   int                    `json:"thinkingTokens,omitempty"`
+	TotalTokens      int                    `json:"totalTokens,omitempty"`
+	LatencyMs        int64                  `json:"latencyMs"`
+	ModelId          string                 `json:"modelId"`
+	Timestamp        string                 `json:"timestamp"`
+	Turn             int                    `json:"turn,omitempty"`
+	ProcessingTimeMs int64                  `json:"processingTimeMs,omitempty"`
+	TokenUsage       *TokenUsage            `json:"tokenUsage,omitempty"`
+	ModelConfig      *ModelConfig           `json:"modelConfig,omitempty"`
+	Metadata         map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // ModelConfig represents Bedrock model configuration


### PR DESCRIPTION
## Summary
- add missing fields to shared `BedrockResponse`
- update ExecuteTurn2Combined changelog

## Testing
- `go vet ./...` *(fails: cannot download modules)*
- `go build ./...` *(fails: cannot download modules)*

------
https://chatgpt.com/codex/tasks/task_b_683c79f2a9a8832db8217dc055fb3d45