### PR TITLE
Fix temperature config validation

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.2.15] - 2025-06-03 - Temperature Validation Fix
+### Fixed
+- Case-insensitive `THINKING_TYPE` comparison prevents misconfiguration.
+- Configuration validation rejects `TEMPERATURE=1` unless thinking is enabled.
+
 ## [2.2.14] - 2025-06-02 - BedrockResponse Struct Update
 ### Fixed
 - Added missing fields to `BedrockResponse` in shared schema to resolve compilation errors.

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client.go
@@ -2,6 +2,7 @@ package bedrock
 
 import (
 	"context"
+	"strings"
 
 	"workflow-function/shared/bedrock"
 	"workflow-function/shared/errors"
@@ -66,6 +67,14 @@ func (c *Client) ValidateConfiguration() error {
 	if c.config.Temperature < 0 || c.config.Temperature > 1 {
 		return errors.NewValidationError("temperature must be between 0 and 1",
 			map[string]interface{}{"current_value": c.config.Temperature})
+	}
+
+	if c.config.Temperature == 1 && !strings.EqualFold(c.config.ThinkingType, "enable") {
+		return errors.NewValidationError("temperature may only be set to 1 when thinking is enabled",
+			map[string]interface{}{
+				"current_value": c.config.Temperature,
+				"thinking_type": c.config.ThinkingType,
+			})
 	}
 
 	return nil

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"workflow-function/shared/errors"
@@ -137,5 +138,5 @@ func (c *Config) DatePartitionFromTimestamp(ts string) (string, error) {
 // Thinking is enabled only when THINKING_TYPE is explicitly set to "enable"
 // Thinking is disabled when THINKING_TYPE is "disable" or unset (empty string)
 func (c *Config) IsThinkingEnabled() bool {
-	return c.Processing.ThinkingType == "enable"
+	return strings.EqualFold(c.Processing.ThinkingType, "enable")
 }


### PR DESCRIPTION
## Summary
- ensure thinking config check is case-insensitive
- reject `TEMPERATURE=1` unless thinking is enabled
- document fix in changelog

## Testing
- `gofmt -w product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go`
- `gofmt -w product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client.go`

------
https://chatgpt.com/codex/tasks/task_b_683c7f384a5c832d88530b657736f4bb