### PR TITLE
Add missing golang.org/x/image dependency

### DIFF
--- a/product-approach/workflow-function/FetchImages/go.mod
+++ b/product-approach/workflow-function/FetchImages/go.mod
@@ -3,16 +3,17 @@ module workflow-function/FetchImages
 go 1.24
 
 require (
-	github.com/aws/aws-lambda-go v1.48.0
-	github.com/aws/aws-sdk-go-v2 v1.36.3
-	github.com/aws/aws-sdk-go-v2/config v1.29.14
-	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.19.0
-	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3
-	github.com/aws/smithy-go v1.22.3
-	workflow-function/shared/logger v0.0.0
-	workflow-function/shared/s3state v0.0.0
-	workflow-function/shared/schema v0.0.0
+    github.com/aws/aws-lambda-go v1.48.0
+    github.com/aws/aws-sdk-go-v2 v1.36.3
+    github.com/aws/aws-sdk-go-v2/config v1.29.14
+    github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.19.0
+    github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1
+    github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3
+    github.com/aws/smithy-go v1.22.3
+    golang.org/x/image v0.26.0
+    workflow-function/shared/logger v0.0.0
+    workflow-function/shared/s3state v0.0.0
+    workflow-function/shared/schema v0.0.0
 )
 
 require (

--- a/product-approach/workflow-function/FetchImages/go.sum
+++ b/product-approach/workflow-function/FetchImages/go.sum
@@ -52,3 +52,5 @@ github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+golang.org/x/image v0.26.0 h1:4XjIFEZWQmCZi6Wv8BoxsDhRU3RVnLX04dToTDAEPlY=
+golang.org/x/image v0.26.0/go.mod h1:lcxbMFAovzpnJxzXS3nyL83K27tmqtKzIJpctK8YO5c=


### PR DESCRIPTION
## Summary
- add `golang.org/x/image v0.26.0` to FetchImages module
- update `go.sum` with checksums for the new dependency

## Testing
- `go mod tidy` *(fails: no route to host)*
- `go build ./...` *(fails: cannot load module ../ExecuteTurn1)*

------
https://chatgpt.com/codex/tasks/task_b_683d5ee581ac832d820b756e38fa22aa