### PR TITLE
Remove base64 references from envelope state

### DIFF
--- a/product-approach/workflow-function/FetchImages/internal/service/fetch_service.go
+++ b/product-approach/workflow-function/FetchImages/internal/service/fetch_service.go
@@ -149,6 +149,11 @@ func (s *FetchService) ProcessRequest(
 		s.stateManager.AddSummary(envelope, "previousVerificationId", verificationContext.PreviousVerificationId)
 	}
 
+	if envelope != nil && envelope.References != nil {
+		delete(envelope.References, "images_reference_base64")
+		delete(envelope.References, "images_checking_base64")
+	}
+
 	// Create and return response
 	return &models.FetchImagesResponse{
 		VerificationId: verificationContext.VerificationId,

--- a/product-approach/workflow-function/FetchImages/internal/service/s3state_manager.go
+++ b/product-approach/workflow-function/FetchImages/internal/service/s3state_manager.go
@@ -157,12 +157,6 @@ func (s *S3StateManager) StoreBase64Image(envelope *s3state.Envelope, imageType,
 		return nil, fmt.Errorf("failed to store Base64 image: %w", err)
 	}
 
-	if envelope.References == nil {
-		envelope.References = make(map[string]*s3state.Reference)
-	}
-	refKey := fmt.Sprintf("images_%s_base64", imageType)
-	envelope.References[refKey] = ref
-
 	return ref, nil
 }
 


### PR DESCRIPTION
## Summary
- stop adding Base64 image references to the S3 state envelope
- purge any existing Base64 reference keys before returning the envelope

## Testing
- `go test ./...` *(fails: cannot load modules)*

------
https://chatgpt.com/codex/tasks/task_b_683d6ac846a4832da8b53130da7b6e1f