### PR TITLE
Update thinking content handling

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/s3.go
@@ -855,8 +855,7 @@ func buildAssistantContent(assistantResponse string, thinkingContent string, inc
 	// Add thinking content if available and requested
 	if thinkingContent != "" && includeThinkingContentInMessage {
 		content = append(content, map[string]interface{}{
-			"type": "thinking",
-			"text": thinkingContent,
+			"thinking": thinkingContent,
 		})
 	}
 

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3_turn2.go
@@ -41,8 +41,7 @@ func buildAssistantContent(assistantResponse string, thinkingContent string, inc
 
 	if thinkingContent != "" && includeThinkingContentInMessage {
 		content = append(content, map[string]interface{}{
-			"type": "thinking",
-			"text": thinkingContent,
+			"thinking": thinkingContent,
 		})
 	}
 


### PR DESCRIPTION
## Summary
- update buildAssistantContent helpers to store thinking blocks under the `thinking` key
- adjust Turn2 handler to parse conversations with the new thinking key

## Testing
- `go test ./...` *(fails: cannot load module product-approach/workflow-function/ExecuteTurn1 listed in go.work file)*

------
https://chatgpt.com/codex/tasks/task_b_683e610a7de4832d99f4d1d6c914944d