### PR TITLE
Add S3 URI to conversation logs

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the ExecuteTurn1Combined function will be documented in this file.
 
+## [2.8.4] - 2025-06-06
+### Changed
+- `turn1-conversation.json` now references the Base64 image using an S3 URI rather than an inline placeholder.
+
 ## [2.8.3] - 2025-06-02 - THINKING_TYPE Fix
 
 ### Fixed

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/handler.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/handler.go
@@ -190,7 +190,7 @@ func (h *Handler) Handle(ctx context.Context, req *models.Turn1Request) (resp *s
 	}
 
 	// Store conversation with complete schema compliance
-	convRef, convErr := h.storageManager.StoreConversation(ctx, req.VerificationID, loadResult.SystemPrompt, promptResult.Prompt, loadResult.Base64Image, bedrockTextOutput, thinkingContent, &invokeResult.Response.TokenUsage, invokeResult.Duration.Milliseconds(), invokeResult.Response.RequestID, h.cfg.AWS.BedrockModel, invokeResult.Response.Metadata)
+	convRef, convErr := h.storageManager.StoreConversation(ctx, req.VerificationID, loadResult.SystemPrompt, promptResult.Prompt, loadResult.Base64Image, req.S3Refs.Images.ReferenceBase64, bedrockTextOutput, thinkingContent, &invokeResult.Response.TokenUsage, invokeResult.Duration.Milliseconds(), invokeResult.Response.RequestID, h.cfg.AWS.BedrockModel, invokeResult.Response.Metadata)
 	if convErr != nil {
 		h.log.Warn("failed to store conversation", map[string]interface{}{
 			"error": convErr.Error(),
@@ -383,7 +383,7 @@ func (h *Handler) HandleForStepFunction(ctx context.Context, req *models.Turn1Re
 	}
 
 	// Store conversation with complete schema compliance
-	convRef, convErr := h.storageManager.StoreConversation(ctx, req.VerificationID, loadResult.SystemPrompt, promptResult.Prompt, loadResult.Base64Image, bedrockTextOutput, thinkingContent, &invokeResult.Response.TokenUsage, invokeResult.Duration.Milliseconds(), invokeResult.Response.RequestID, h.cfg.AWS.BedrockModel, invokeResult.Response.Metadata)
+	convRef, convErr := h.storageManager.StoreConversation(ctx, req.VerificationID, loadResult.SystemPrompt, promptResult.Prompt, loadResult.Base64Image, req.S3Refs.Images.ReferenceBase64, bedrockTextOutput, thinkingContent, &invokeResult.Response.TokenUsage, invokeResult.Duration.Milliseconds(), invokeResult.Response.RequestID, h.cfg.AWS.BedrockModel, invokeResult.Response.Metadata)
 	if convErr != nil {
 		return nil, convErr
 	}
@@ -448,7 +448,7 @@ func (h *Handler) HandleForStepFunction(ctx context.Context, req *models.Turn1Re
 	}
 
 	// Store conversation with complete schema compliance (second call for step function)
-	convRef, convErr = h.storageManager.StoreConversation(ctx, req.VerificationID, loadResult.SystemPrompt, promptResult.Prompt, loadResult.Base64Image, bedrockTextOutput, thinkingContent, &invokeResult.Response.TokenUsage, invokeResult.Duration.Milliseconds(), invokeResult.Response.RequestID, h.cfg.AWS.BedrockModel, invokeResult.Response.Metadata)
+	convRef, convErr = h.storageManager.StoreConversation(ctx, req.VerificationID, loadResult.SystemPrompt, promptResult.Prompt, loadResult.Base64Image, req.S3Refs.Images.ReferenceBase64, bedrockTextOutput, thinkingContent, &invokeResult.Response.TokenUsage, invokeResult.Duration.Milliseconds(), invokeResult.Response.RequestID, h.cfg.AWS.BedrockModel, invokeResult.Response.Metadata)
 	if convErr != nil {
 		h.log.Warn("failed to store conversation", map[string]interface{}{
 			"error": convErr.Error(),

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/storage_manager.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/storage_manager.go
@@ -127,7 +127,7 @@ func (m *StorageManager) StorePrompt(ctx context.Context, req *models.Turn1Reque
 }
 
 // StoreConversation stores turn1 conversation messages in S3 with complete schema compliance
-func (m *StorageManager) StoreConversation(ctx context.Context, verificationID string, systemPrompt string, userPrompt string, base64Image string, assistantResponse string, thinkingContent string, tokenUsage *schema.TokenUsage, latencyMs int64, bedrockRequestId string, modelId string, bedrockResponseMetadata map[string]interface{}) (models.S3Reference, error) {
+func (m *StorageManager) StoreConversation(ctx context.Context, verificationID string, systemPrompt string, userPrompt string, base64Image string, base64Ref models.S3Reference, assistantResponse string, thinkingContent string, tokenUsage *schema.TokenUsage, latencyMs int64, bedrockRequestId string, modelId string, bedrockResponseMetadata map[string]interface{}) (models.S3Reference, error) {
 	if verificationID == "" {
 		return models.S3Reference{}, errors.NewValidationError(
 			"verification ID required for conversation storage",
@@ -135,7 +135,7 @@ func (m *StorageManager) StoreConversation(ctx context.Context, verificationID s
 	}
 
 	start := time.Now()
-	ref, err := m.s3.StoreTurn1Conversation(ctx, verificationID, systemPrompt, userPrompt, base64Image, assistantResponse, thinkingContent, tokenUsage, latencyMs, bedrockRequestId, modelId, bedrockResponseMetadata)
+	ref, err := m.s3.StoreTurn1Conversation(ctx, verificationID, systemPrompt, userPrompt, base64Image, base64Ref, assistantResponse, thinkingContent, tokenUsage, latencyMs, bedrockRequestId, modelId, bedrockResponseMetadata)
 	if err != nil {
 		m.log.Warn("s3 conversation-store warning", map[string]interface{}{
 			"error":  err.Error(),

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/s3.go
@@ -143,7 +143,7 @@ type S3StateManager interface {
 	StoreProcessedTurn1Markdown(ctx context.Context, verificationID string, markdownContent string) (models.S3Reference, error)
 	StoreConversationTurn(ctx context.Context, verificationID string, turnData *schema.TurnResponse) (models.S3Reference, error)
 	// StoreTurn1Conversation stores full turn1 conversation messages with complete schema compliance
-	StoreTurn1Conversation(ctx context.Context, verificationID string, systemPrompt string, userPrompt string, base64Image string, assistantResponse string, thinkingContent string, tokenUsage *schema.TokenUsage, latencyMs int64, bedrockRequestId string, modelId string, bedrockResponseMetadata map[string]interface{}) (models.S3Reference, error)
+	StoreTurn1Conversation(ctx context.Context, verificationID string, systemPrompt string, userPrompt string, base64Image string, base64Ref models.S3Reference, assistantResponse string, thinkingContent string, tokenUsage *schema.TokenUsage, latencyMs int64, bedrockRequestId string, modelId string, bedrockResponseMetadata map[string]interface{}) (models.S3Reference, error)
 	StoreTemplateProcessor(ctx context.Context, verificationID string, processor *schema.TemplateProcessor) (models.S3Reference, error)
 	StoreProcessingMetrics(ctx context.Context, verificationID string, metrics *schema.ProcessingMetrics) (models.S3Reference, error)
 	LoadProcessingState(ctx context.Context, verificationID string, stateType string) (interface{}, error)
@@ -863,7 +863,7 @@ func buildAssistantContent(assistantResponse string, thinkingContent string, inc
 }
 
 // StoreTurn1Conversation stores full conversation messages for turn1 with complete schema compliance
-func (m *s3Manager) StoreTurn1Conversation(ctx context.Context, verificationID string, systemPrompt string, userPrompt string, base64Image string, assistantResponse string, thinkingContent string, tokenUsage *schema.TokenUsage, latencyMs int64, bedrockRequestId string, modelId string, bedrockResponseMetadata map[string]interface{}) (models.S3Reference, error) {
+func (m *s3Manager) StoreTurn1Conversation(ctx context.Context, verificationID string, systemPrompt string, userPrompt string, base64Image string, base64Ref models.S3Reference, assistantResponse string, thinkingContent string, tokenUsage *schema.TokenUsage, latencyMs int64, bedrockRequestId string, modelId string, bedrockResponseMetadata map[string]interface{}) (models.S3Reference, error) {
 	if verificationID == "" {
 		return models.S3Reference{}, errors.NewValidationError(
 			"verification ID required for storing turn1 conversation",
@@ -897,7 +897,7 @@ func (m *s3Manager) StoreTurn1Conversation(ctx context.Context, verificationID s
 					"image": map[string]interface{}{
 						"format": "png",
 						"source": map[string]interface{}{
-							"bytes": "<Base64-reference-image>", // Placeholder for actual base64
+							"s3Uri": fmt.Sprintf("s3://%s/%s", base64Ref.Bucket, base64Ref.Key),
 						},
 					},
 				},

--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.1.5] - 2025-06-06
+### Changed
+- `turn2-conversation.json` now stores the user image source as an S3 URI.
+
 ## [2.1.4] - 2025-06-02
 ### Fixed
 - Fixed reflection panic when processing Bedrock responses by skipping unexported struct fields

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/turn2_handler.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/turn2_handler.go
@@ -382,7 +382,7 @@ func (h *Turn2Handler) ProcessTurn2Request(ctx context.Context, req *models.Turn
 		}
 	}
 
-	convRef, convErr := h.s3.StoreTurn2Conversation(ctx, req.VerificationID, turn1Messages, loadResult.SystemPrompt, prompt, loadResult.Base64Image, bedrockTextOutput, bedrockResponse.Thinking, thinkingBlocks, &schema.TokenUsage{
+	convRef, convErr := h.s3.StoreTurn2Conversation(ctx, req.VerificationID, turn1Messages, loadResult.SystemPrompt, prompt, loadResult.Base64Image, req.S3Refs.Images.CheckingBase64, bedrockTextOutput, bedrockResponse.Thinking, thinkingBlocks, &schema.TokenUsage{
 		InputTokens:    bedrockResponse.InputTokens,
 		OutputTokens:   bedrockResponse.OutputTokens,
 		ThinkingTokens: 0,

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
@@ -142,8 +142,8 @@ type S3StateManager interface {
 	StoreProcessedTurn1Response(ctx context.Context, verificationID string, analysisData *bedrockparser.ParsedTurn1Data) (models.S3Reference, error)
 	StoreProcessedTurn1Markdown(ctx context.Context, verificationID string, markdownContent string) (models.S3Reference, error)
 	StoreConversationTurn(ctx context.Context, verificationID string, turnData *schema.TurnResponse) (models.S3Reference, error)
-       // StoreTurn2Conversation builds and stores full conversation messages for turn2
-       StoreTurn2Conversation(ctx context.Context, verificationID string, turn1Messages []schema.BedrockMessage, systemPrompt string, userPrompt string, base64Image string, assistantResponse string, thinkingContent string, thinkingBlocks []interface{}, tokenUsage *schema.TokenUsage, latencyMs int64, bedrockRequestId string, modelId string, bedrockResponseMetadata map[string]interface{}) (models.S3Reference, error)
+	// StoreTurn2Conversation builds and stores full conversation messages for turn2
+	StoreTurn2Conversation(ctx context.Context, verificationID string, turn1Messages []schema.BedrockMessage, systemPrompt string, userPrompt string, base64Image string, base64Ref models.S3Reference, assistantResponse string, thinkingContent string, thinkingBlocks []interface{}, tokenUsage *schema.TokenUsage, latencyMs int64, bedrockRequestId string, modelId string, bedrockResponseMetadata map[string]interface{}) (models.S3Reference, error)
 	StoreTemplateProcessor(ctx context.Context, verificationID string, processor *schema.TemplateProcessor) (models.S3Reference, error)
 	StoreProcessingMetrics(ctx context.Context, verificationID string, metrics *schema.ProcessingMetrics) (models.S3Reference, error)
 	LoadProcessingState(ctx context.Context, verificationID string, stateType string) (interface{}, error)
@@ -823,7 +823,7 @@ func (m *s3Manager) StorePrompt(ctx context.Context, verificationID string, turn
 	}
 
 	key := fmt.Sprintf("prompts/turn%d-prompt.json", turn)
-	
+
 	// Check if prompt is already a JSON string (for Turn2)
 	if promptStr, ok := prompt.(string); ok {
 		// Validate that it's valid JSON
@@ -839,7 +839,7 @@ func (m *s3Manager) StorePrompt(ctx context.Context, verificationID string, turn
 			return m.fromStateReference(stateRef), nil
 		}
 	}
-	
+
 	// For non-JSON strings or objects, use the original StoreJSON method
 	stateRef, err := m.stateManager.StoreJSON(m.datePath(verificationID), key, prompt)
 	if err != nil {

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3_turn2.go
@@ -332,7 +332,7 @@ func (m *s3Manager) StoreTurn2Markdown(ctx context.Context, verificationID strin
 }
 
 // StoreTurn2Conversation stores full conversation messages for turn2
-func (m *s3Manager) StoreTurn2Conversation(ctx context.Context, verificationID string, turn1Messages []schema.BedrockMessage, systemPrompt string, userPrompt string, base64Image string, assistantResponse string, thinkingContent string, thinkingBlocks []interface{}, tokenUsage *schema.TokenUsage, latencyMs int64, bedrockRequestId string, modelId string, bedrockResponseMetadata map[string]interface{}) (models.S3Reference, error) {
+func (m *s3Manager) StoreTurn2Conversation(ctx context.Context, verificationID string, turn1Messages []schema.BedrockMessage, systemPrompt string, userPrompt string, base64Image string, base64Ref models.S3Reference, assistantResponse string, thinkingContent string, thinkingBlocks []interface{}, tokenUsage *schema.TokenUsage, latencyMs int64, bedrockRequestId string, modelId string, bedrockResponseMetadata map[string]interface{}) (models.S3Reference, error) {
 	if verificationID == "" {
 		return models.S3Reference{}, errors.NewValidationError(
 			"verification ID required for storing Turn2 conversation",
@@ -366,7 +366,7 @@ func (m *s3Manager) StoreTurn2Conversation(ctx context.Context, verificationID s
 				"image": map[string]interface{}{
 					"format": "png",
 					"source": map[string]interface{}{
-						"bytes": "<Base64-reference-image>",
+						"s3Uri": fmt.Sprintf("s3://%s/%s", base64Ref.Bucket, base64Ref.Key),
 					},
 				},
 			},


### PR DESCRIPTION
## Summary
- include S3 reference when storing Turn1 conversation data
- store Turn2 conversation with S3 URI for checking image
- update handlers to pass new S3 reference argument
- document S3 URI injection in CHANGELOGs

## Testing
- `go vet ./...` *(fails: cannot load module listed in go.work)*

------
https://chatgpt.com/codex/tasks/task_b_683e69d0b818832da16b8a4134eec184