### PR TITLE
Fix conversation update metadata initialization

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the ExecuteTurn1Combined function will be documented in this file.
 
+## [2.8.5] - 2025-06-07
+### Fixed
+- Resolved DynamoDB marshalling errors during conversation history updates when
+  existing items lacked `metadata` or `history` attributes.
+
 ## [2.8.4] - 2025-06-06
 ### Changed
 - `turn1-conversation.json` now references the Base64 image using an S3 URI rather than an inline placeholder.

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/dynamodb.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/dynamodb.go
@@ -533,6 +533,12 @@ func (d *dynamoClient) updateConversationTurnInternal(ctx context.Context, verif
 				WithContext("verificationId", verificationID).
 				WithContext("table", d.conversationTable)
 		}
+		if conversationTracker.History == nil {
+			conversationTracker.History = make([]interface{}, 0)
+		}
+		if conversationTracker.Metadata == nil {
+			conversationTracker.Metadata = make(map[string]interface{})
+		}
 	} else {
 		// Initialize if not exists
 		conversationTracker = schema.ConversationTracker{

--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.1.6] - 2025-06-07
+### Fixed
+- Conversation history updates could fail when existing items lacked `metadata`
+  or `history` attributes. Missing fields are now initialized after loading the
+  record from DynamoDB.
+
 ## [2.1.5] - 2025-06-06
 ### Changed
 - `turn2-conversation.json` now stores the user image source as an S3 URI.

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go
@@ -535,6 +535,12 @@ func (d *dynamoClient) updateConversationTurnInternal(ctx context.Context, verif
 				WithContext("verificationId", verificationID).
 				WithContext("table", d.conversationTable)
 		}
+		if conversationTracker.History == nil {
+			conversationTracker.History = make([]interface{}, 0)
+		}
+		if conversationTracker.Metadata == nil {
+			conversationTracker.Metadata = make(map[string]interface{})
+		}
 	} else {
 		// Initialize if not exists
 		conversationTracker = schema.ConversationTracker{


### PR DESCRIPTION
## Summary
- initialize `ConversationTracker` fields when loaded from DynamoDB
- document fix in each ExecuteTurn changelog

## Testing
- `go vet ./...` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_b_683e992a8a70832d92d590edb9b7798c