### PR TITLE
Add prompt recovery from Turn1 conversation

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/turn2_handler.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/turn2_handler.go
@@ -93,7 +93,7 @@ func (h *Turn2Handler) ProcessTurn2Request(ctx context.Context, req *models.Turn
 	var loadedTurn1Response *schema.TurnResponse
 	if req.S3Refs.Turn1.RawResponse.Key != "" {
 		var err error
-		loadedTurn1Response, err = h.s3.LoadTurn1SchemaResponse(ctx, req.S3Refs.Turn1.RawResponse)
+		loadedTurn1Response, err = h.s3.LoadTurn1SchemaResponse(ctx, req.S3Refs.Turn1.RawResponse, &req.S3Refs.Turn1.Conversation)
 		if err != nil {
 			wfErr := errors.WrapError(err, errors.ErrorTypeS3,
 				"failed to load Turn1 raw response", true).

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3.go
@@ -152,7 +152,9 @@ type S3StateManager interface {
 	LoadTurn1ProcessedResponse(ctx context.Context, ref models.S3Reference) (*schema.Turn1ProcessedResponse, error)
 	LoadTurn1RawResponse(ctx context.Context, ref models.S3Reference) (json.RawMessage, error)
 	// LoadTurn1SchemaResponse loads the raw Turn1 response into schema.TurnResponse
-	LoadTurn1SchemaResponse(ctx context.Context, ref models.S3Reference) (*schema.TurnResponse, error)
+	// conversationRef optionally provides a path to turn1-conversation.json to recover
+	// missing prompt or response content when the raw response lacks these fields
+	LoadTurn1SchemaResponse(ctx context.Context, ref models.S3Reference, conversationRef *models.S3Reference) (*schema.TurnResponse, error)
 
 	// Turn2 specific storage helpers
 	StoreTurn2Response(ctx context.Context, verificationID string, response *bedrockparser.ParsedTurn2Data) (models.S3Reference, error)


### PR DESCRIPTION
## Summary
- extend `LoadTurn1SchemaResponse` to optionally recover prompt from conversation history
- use new parameter in turn2 handler
- log when Turn1 prompt is recovered

## Testing
- `go build ./...` *(fails: cannot load module)*

------
https://chatgpt.com/codex/tasks/task_b_683eaf576e08832d9f9c1acf07269910