### PR TITLE
Add FinalizeAndStoreResults Lambda

### DIFF
--- a/product-approach/workflow-function/FinalizeAndStoreResults/CHANGELOG.md
+++ b/product-approach/workflow-function/FinalizeAndStoreResults/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0] - 2025-06-09
+### Added
+- Initial implementation of `FinalizeAndStoreResults` Lambda function.
+- Parses Turn 2 processed results from S3 and writes final verification record to DynamoDB.
+- Updates conversation history status to `WORKFLOW_COMPLETED`.
+

--- a/product-approach/workflow-function/FinalizeAndStoreResults/README.md
+++ b/product-approach/workflow-function/FinalizeAndStoreResults/README.md
@@ -1,0 +1,15 @@
+# FinalizeAndStoreResults
+
+This Lambda function finalizes a vending machine verification workflow by loading
+results from S3, storing them in DynamoDB and updating conversation history.
+It expects S3 references to initialization data and processed Turn 2 results
+from the Step Functions state machine.
+
+The function retrieves initialization metadata, parses the Turn 2 output to
+extract the verification summary, then writes a consolidated record to the
+`VerificationResults` table and marks the conversation as completed in the
+`ConversationHistory` table.
+
+The output of the Lambda provides a concise summary including the final
+verification status and accuracy metrics.
+

--- a/product-approach/workflow-function/FinalizeAndStoreResults/cmd/finalizeandstoreresults/main.go
+++ b/product-approach/workflow-function/FinalizeAndStoreResults/cmd/finalizeandstoreresults/main.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/aws-lambda-go/lambda"
+
+	"workflow-function/FinalizeAndStoreResults/internal/config"
+	"workflow-function/FinalizeAndStoreResults/internal/dynamodbhelper"
+	"workflow-function/FinalizeAndStoreResults/internal/models"
+	"workflow-function/FinalizeAndStoreResults/internal/parser"
+	"workflow-function/FinalizeAndStoreResults/internal/s3helper"
+	"workflow-function/shared/logger"
+)
+
+var (
+	appConfig  *config.LambdaConfig
+	awsClients *config.AWSClients
+	log        logger.Logger
+)
+
+func init() {
+	var err error
+	log = logger.New("FinalizeAndStoreResults", "main")
+
+	appConfig, err = config.LoadEnvConfig()
+	if err != nil {
+		log.Error("failed_to_load_config", map[string]interface{}{"error": err.Error()})
+		os.Exit(1)
+	}
+
+	awsClients, err = config.NewAWSClients(context.Background())
+	if err != nil {
+		log.Error("failed_to_init_aws", map[string]interface{}{"error": err.Error()})
+		os.Exit(1)
+	}
+}
+
+func HandleRequest(ctx context.Context, event models.LambdaInput) (models.LambdaOutput, error) {
+	log.LogReceivedEvent(event)
+
+	if event.References.InitializationS3Ref.Bucket == "" || event.References.InitializationS3Ref.Key == "" {
+		return models.LambdaOutput{}, fmt.Errorf("initialization S3 reference missing")
+	}
+	if event.References.Turn2ProcessedS3Ref.Bucket == "" || event.References.Turn2ProcessedS3Ref.Key == "" {
+		return models.LambdaOutput{}, fmt.Errorf("turn2 processed S3 reference missing")
+	}
+
+	var initData models.InitializationData
+	err := s3helper.GetS3ObjectAsJSON(ctx, awsClients.S3Client, event.References.InitializationS3Ref.Bucket, event.References.InitializationS3Ref.Key, &initData)
+	if err != nil {
+		log.Error("fetch_init_failed", map[string]interface{}{"error": err.Error(), "verificationId": event.VerificationID})
+		return models.LambdaOutput{}, err
+	}
+
+	turn2Bytes, err := s3helper.GetS3Object(ctx, awsClients.S3Client, event.References.Turn2ProcessedS3Ref.Bucket, event.References.Turn2ProcessedS3Ref.Key)
+	if err != nil {
+		log.Error("fetch_turn2_failed", map[string]interface{}{"error": err.Error(), "verificationId": event.VerificationID})
+		return models.LambdaOutput{}, err
+	}
+
+	parsed, err := parser.ParseTurn2ResponseData(turn2Bytes)
+	if err != nil {
+		log.Error("parse_turn2_failed", map[string]interface{}{"error": err.Error(), "verificationId": event.VerificationID})
+		return models.LambdaOutput{}, err
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	item := models.VerificationResultItem{
+		VerificationID:         event.VerificationID,
+		VerificationAt:         now,
+		VerificationType:       initData.VerificationType,
+		LayoutID:               &initData.LayoutID,
+		LayoutPrefix:           initData.LayoutPrefix,
+		VendingMachineID:       initData.VendingMachineID,
+		ReferenceImageUrl:      initData.ReferenceImageUrl,
+		CheckingImageUrl:       initData.CheckingImageUrl,
+		VerificationStatus:     parsed.VerificationStatus,
+		CurrentStatus:          "COMPLETED",
+		LastUpdatedAt:          now,
+		ProcessingStartedAt:    initData.ProcessingStartedAt,
+		InitialConfirmation:    parsed.InitialConfirmation,
+		VerificationSummary:    parsed.VerificationSummary,
+		PreviousVerificationID: initData.PreviousVerificationID,
+	}
+	if initData.LayoutID == 0 {
+		item.LayoutID = nil
+	}
+
+	err = dynamodbhelper.StoreVerificationResult(ctx, awsClients.DynamoDBClient, appConfig.VerificationResultsTable, item)
+	if err != nil {
+		log.Error("dynamodb_store_failed", map[string]interface{}{"error": err.Error(), "verificationId": event.VerificationID})
+		return models.LambdaOutput{}, err
+	}
+
+	err = dynamodbhelper.UpdateConversationHistory(ctx, awsClients.DynamoDBClient, appConfig.ConversationHistoryTable, event.VerificationID)
+	if err != nil {
+		log.Error("conversation_update_failed", map[string]interface{}{"error": err.Error(), "verificationId": event.VerificationID})
+		return models.LambdaOutput{}, err
+	}
+
+	output := models.LambdaOutput{
+		VerificationID:      event.VerificationID,
+		VerificationAt:      now,
+		Status:              "COMPLETED",
+		VerificationStatus:  parsed.VerificationStatus,
+		VerificationSummary: parsed.VerificationSummary,
+		Message:             "Verification finalized and stored",
+	}
+
+	log.LogOutputEvent(output)
+	return output, nil
+}
+
+func main() {
+	lambda.Start(HandleRequest)
+}

--- a/product-approach/workflow-function/FinalizeAndStoreResults/go.mod
+++ b/product-approach/workflow-function/FinalizeAndStoreResults/go.mod
@@ -1,39 +1,38 @@
-module workflow-function/FinalizeWithErrorFunction
+module workflow-function/FinalizeAndStoreResults
 
-go 1.24
+go 1.21
 
 replace workflow-function/shared/logger => ../shared/logger
-
 replace workflow-function/shared/schema => ../shared/schema
-
 replace workflow-function/shared/s3state => ../shared/s3state
-
 replace workflow-function/shared/errors => ../shared/errors
 
 require (
-	github.com/aws/aws-lambda-go v1.48.0
-	workflow-function/shared/logger v0.0.0-00010101000000-000000000000
-	workflow-function/shared/s3state v0.0.0-00010101000000-000000000000
-	workflow-function/shared/schema v0.0.0-00010101000000-000000000000
+    github.com/aws/aws-lambda-go v1.48.0
+    github.com/aws/aws-sdk-go-v2 v1.36.3
+    github.com/aws/aws-sdk-go-v2/config v1.27.9
+    github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1
+    github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3
+    workflow-function/shared/logger v0.0.0-00010101000000-000000000000
+    workflow-function/shared/s3state v0.0.0-00010101000000-000000000000
+    workflow-function/shared/schema v0.0.0-00010101000000-000000000000
+    workflow-function/shared/errors v0.0.0
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.27.9 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.17.9 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.0 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.1 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sso v1.20.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.28.5 // indirect
-	github.com/aws/smithy-go v1.22.3 // indirect
+    github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
+    github.com/aws/aws-sdk-go-v2/credentials v1.17.9 // indirect
+    github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.0 // indirect
+    github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
+    github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
+    github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
+    github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 // indirect
+    github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
+    github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.1 // indirect
+    github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
+    github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15 // indirect
+    github.com/aws/aws-sdk-go-v2/service/sso v1.20.3 // indirect
+    github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.3 // indirect
+    github.com/aws/aws-sdk-go-v2/service/sts v1.28.5 // indirect
+    github.com/aws/smithy-go v1.22.3 // indirect
 )

--- a/product-approach/workflow-function/FinalizeAndStoreResults/internal/config/config.go
+++ b/product-approach/workflow-function/FinalizeAndStoreResults/internal/config/config.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type LambdaConfig struct {
+	VerificationResultsTable string
+	ConversationHistoryTable string
+	StateBucket              string
+}
+
+func LoadEnvConfig() (*LambdaConfig, error) {
+	cfg := &LambdaConfig{}
+	cfg.VerificationResultsTable = os.Getenv("DYNAMODB_VERIFICATION_TABLE")
+	cfg.ConversationHistoryTable = os.Getenv("DYNAMODB_CONVERSATION_TABLE")
+	cfg.StateBucket = os.Getenv("STATE_BUCKET")
+
+	if cfg.VerificationResultsTable == "" {
+		return nil, fmt.Errorf("missing env DYNAMODB_VERIFICATION_TABLE")
+	}
+	if cfg.ConversationHistoryTable == "" {
+		return nil, fmt.Errorf("missing env DYNAMODB_CONVERSATION_TABLE")
+	}
+	if cfg.StateBucket == "" {
+		return nil, fmt.Errorf("missing env STATE_BUCKET")
+	}
+	return cfg, nil
+}
+
+type AWSClients struct {
+	S3Client       *s3.Client
+	DynamoDBClient *dynamodb.Client
+}
+
+func NewAWSClients(ctx context.Context) (*AWSClients, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &AWSClients{
+		S3Client:       s3.NewFromConfig(cfg),
+		DynamoDBClient: dynamodb.NewFromConfig(cfg),
+	}, nil
+}

--- a/product-approach/workflow-function/FinalizeAndStoreResults/internal/dynamodbhelper/dynamodbhelper.go
+++ b/product-approach/workflow-function/FinalizeAndStoreResults/internal/dynamodbhelper/dynamodbhelper.go
@@ -1,0 +1,39 @@
+package dynamodbhelper
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"workflow-function/FinalizeAndStoreResults/internal/models"
+)
+
+func StoreVerificationResult(ctx context.Context, client *dynamodb.Client, tableName string, item models.VerificationResultItem) error {
+	av, err := attributevalue.MarshalMap(item)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: &tableName,
+		Item:      av,
+	})
+	return err
+}
+
+func UpdateConversationHistory(ctx context.Context, client *dynamodb.Client, tableName, verificationID string) error {
+	_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: &tableName,
+		Key: map[string]types.AttributeValue{
+			"verificationId": &types.AttributeValueMemberS{Value: verificationID},
+		},
+		UpdateExpression: aws.String("SET turnStatus = :ts"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":ts": &types.AttributeValueMemberS{Value: "WORKFLOW_COMPLETED"},
+		},
+	})
+	return err
+}

--- a/product-approach/workflow-function/FinalizeAndStoreResults/internal/models/models.go
+++ b/product-approach/workflow-function/FinalizeAndStoreResults/internal/models/models.go
@@ -1,0 +1,104 @@
+package models
+
+// Input to the Lambda function
+
+type S3Reference struct {
+	Bucket string `json:"bucket"`
+	Key    string `json:"key"`
+	ETag   string `json:"etag,omitempty"`
+	Size   int64  `json:"size,omitempty"`
+}
+
+type InputS3References struct {
+	InitializationS3Ref S3Reference `json:"processing_initialization"`
+	Turn1ProcessedS3Ref S3Reference `json:"turn1Processed"`
+	Turn2ProcessedS3Ref S3Reference `json:"turn2Processed"`
+}
+
+type LambdaInput struct {
+	VerificationID string            `json:"verificationId"`
+	References     InputS3References `json:"s3References"`
+	Status         string            `json:"status"`
+}
+
+// Output structs
+
+type OutputDiscrepancyDetails struct {
+	MissingProducts       int `json:"missing_products" dynamodbav:"missing_products"`
+	IncorrectProductTypes int `json:"incorrect_product_types" dynamodbav:"incorrect_product_types"`
+	UnexpectedProducts    int `json:"unexpected_products" dynamodbav:"unexpected_products"`
+}
+
+type OutputVerificationSummary struct {
+	TotalPositionsChecked         int                      `json:"total_positions_checked" dynamodbav:"total_positions_checked"`
+	CorrectPositions              int                      `json:"correct_positions" dynamodbav:"correct_positions"`
+	DiscrepantPositions           int                      `json:"discrepant_positions" dynamodbav:"discrepant_positions"`
+	DiscrepancyDetails            OutputDiscrepancyDetails `json:"discrepancy_details" dynamodbav:"discrepancy_details"`
+	EmptyPositionsInCheckingImage int                      `json:"empty_positions_in_checking_image" dynamodbav:"empty_positions_in_checking_image"`
+	OverallAccuracy               string                   `json:"overall_accuracy" dynamodbav:"overall_accuracy"`
+	OverallConfidence             string                   `json:"overall_confidence" dynamodbav:"overall_confidence"`
+	VerificationOutcome           string                   `json:"verification_outcome" dynamodbav:"verification_outcome"`
+}
+
+type LambdaOutput struct {
+	VerificationID      string                    `json:"verificationId"`
+	VerificationAt      string                    `json:"verificationAt"`
+	Status              string                    `json:"status"`
+	VerificationStatus  string                    `json:"verificationStatus"`
+	VerificationSummary OutputVerificationSummary `json:"verificationSummary"`
+	Message             string                    `json:"message"`
+}
+
+// InitializationData from initialization.json
+
+type InitializationData struct {
+	VerificationID         string `json:"verificationId"`
+	VerificationType       string `json:"verificationType"`
+	ReferenceImageUrl      string `json:"referenceImageUrl"`
+	CheckingImageUrl       string `json:"checkingImageUrl"`
+	VendingMachineID       string `json:"vendingMachineId,omitempty"`
+	LayoutID               int    `json:"layoutId,omitempty"`
+	LayoutPrefix           string `json:"layoutPrefix,omitempty"`
+	PreviousVerificationID string `json:"previousVerificationId,omitempty"`
+	ProcessingStartedAt    string `json:"processingStartedAt"`
+	InitialVerificationAt  string `json:"verificationAt"`
+}
+
+// Parsed Turn2 data
+
+type Turn2ParsedData struct {
+	VerificationSummary OutputVerificationSummary
+	InitialConfirmation string
+	VerificationStatus  string
+}
+
+// DynamoDB item
+
+type VerificationResultItem struct {
+	VerificationID         string                    `dynamodbav:"verificationId"`
+	VerificationAt         string                    `dynamodbav:"verificationAt"`
+	VerificationType       string                    `dynamodbav:"verificationType"`
+	LayoutID               *int                      `dynamodbav:"layoutId,omitempty"`
+	LayoutPrefix           string                    `dynamodbav:"layoutPrefix,omitempty"`
+	VendingMachineID       string                    `dynamodbav:"vendingMachineId,omitempty"`
+	Location               string                    `dynamodbav:"location,omitempty"`
+	ReferenceImageUrl      string                    `dynamodbav:"referenceImageUrl"`
+	CheckingImageUrl       string                    `dynamodbav:"checkingImageUrl"`
+	VerificationStatus     string                    `dynamodbav:"verificationStatus"`
+	CurrentStatus          string                    `dynamodbav:"currentStatus"`
+	LastUpdatedAt          string                    `dynamodbav:"lastUpdatedAt"`
+	ProcessingStartedAt    string                    `dynamodbav:"processingStartedAt,omitempty"`
+	StatusHistory          []map[string]interface{}  `dynamodbav:"statusHistory,omitempty"`
+	ProcessingMetrics      map[string]interface{}    `dynamodbav:"processingMetrics,omitempty"`
+	ErrorTracking          map[string]interface{}    `dynamodbav:"errorTracking,omitempty"`
+	MachineStructure       map[string]interface{}    `dynamodbav:"machineStructure,omitempty"`
+	InitialConfirmation    string                    `dynamodbav:"initialConfirmation,omitempty"`
+	CorrectedRows          []string                  `dynamodbav:"correctedRows,omitempty"`
+	EmptySlotReport        map[string]interface{}    `dynamodbav:"emptySlotReport,omitempty"`
+	ReferenceStatus        map[string]string         `dynamodbav:"referenceStatus,omitempty"`
+	CheckingStatus         map[string]string         `dynamodbav:"checkingStatus,omitempty"`
+	Discrepancies          []map[string]interface{}  `dynamodbav:"discrepancies,omitempty"`
+	VerificationSummary    OutputVerificationSummary `dynamodbav:"verificationSummary"`
+	Metadata               map[string]interface{}    `dynamodbav:"metadata,omitempty"`
+	PreviousVerificationID string                    `dynamodbav:"previousVerificationId,omitempty"`
+}

--- a/product-approach/workflow-function/FinalizeAndStoreResults/internal/parser/parser.go
+++ b/product-approach/workflow-function/FinalizeAndStoreResults/internal/parser/parser.go
@@ -1,0 +1,71 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"workflow-function/FinalizeAndStoreResults/internal/models"
+)
+
+// ParseTurn2ResponseData parses the turn2 processed response
+func ParseTurn2ResponseData(data []byte) (*models.Turn2ParsedData, error) {
+	// Try JSON first
+	var parsed models.Turn2ParsedData
+	if err := json.Unmarshal(data, &parsed); err == nil && parsed.VerificationStatus != "" {
+		return &parsed, nil
+	}
+
+	// Fallback to markdown/text parsing
+	content := string(data)
+	result := models.Turn2ParsedData{}
+
+	// Extract VERIFICATION SUMMARY section
+	summaryRe := regexp.MustCompile(`(?s)VERIFICATION SUMMARY:?\n(.*?)\n\n`)
+	matches := summaryRe.FindStringSubmatch(content)
+	if len(matches) > 1 {
+		summaryLines := strings.Split(strings.TrimSpace(matches[1]), "\n")
+		for _, line := range summaryLines {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+			switch strings.ToLower(key) {
+			case "total positions checked":
+				fmt.Sscan(value, &result.VerificationSummary.TotalPositionsChecked)
+			case "correct positions":
+				fmt.Sscan(value, &result.VerificationSummary.CorrectPositions)
+			case "discrepant positions":
+				fmt.Sscan(value, &result.VerificationSummary.DiscrepantPositions)
+			case "missing products":
+				fmt.Sscan(value, &result.VerificationSummary.DiscrepancyDetails.MissingProducts)
+			case "incorrect product types":
+				fmt.Sscan(value, &result.VerificationSummary.DiscrepancyDetails.IncorrectProductTypes)
+			case "unexpected products":
+				fmt.Sscan(value, &result.VerificationSummary.DiscrepancyDetails.UnexpectedProducts)
+			case "empty positions in checking image":
+				fmt.Sscan(value, &result.VerificationSummary.EmptyPositionsInCheckingImage)
+			case "overall accuracy":
+				result.VerificationSummary.OverallAccuracy = value
+			case "overall confidence":
+				result.VerificationSummary.OverallConfidence = value
+			case "verification outcome":
+				result.VerificationSummary.VerificationOutcome = value
+			case "verification status":
+				result.VerificationStatus = value
+			}
+		}
+	}
+
+	// Extract INITIAL CONFIRMATION section
+	confirmRe := regexp.MustCompile(`(?s)INITIAL CONFIRMATION:?\n(.*?)\n\n`)
+	cm := confirmRe.FindStringSubmatch(content)
+	if len(cm) > 1 {
+		result.InitialConfirmation = strings.TrimSpace(cm[1])
+	}
+
+	return &result, nil
+}

--- a/product-approach/workflow-function/FinalizeAndStoreResults/internal/s3helper/s3helper.go
+++ b/product-approach/workflow-function/FinalizeAndStoreResults/internal/s3helper/s3helper.go
@@ -1,0 +1,36 @@
+package s3helper
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// GetS3Object returns the bytes of an object from S3
+func GetS3Object(ctx context.Context, client *s3.Client, bucket, key string) ([]byte, error) {
+	output, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer output.Body.Close()
+	data, err := io.ReadAll(output.Body)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// GetS3ObjectAsJSON fetches an object and unmarshals JSON into target
+func GetS3ObjectAsJSON(ctx context.Context, client *s3.Client, bucket, key string, target interface{}) error {
+	bytes, err := GetS3Object(ctx, client, bucket, key)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(bytes, target)
+}


### PR DESCRIPTION
## Summary
- implement FinalizeAndStoreResults workflow lambda
- add models, config, helpers and parser
- document module with README and CHANGELOG

## Testing
- `go mod tidy` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_b_683ebe0fc700832dba6f9c81b43e1d27