### PR TITLE
Implement FinalizeWithError Lambda

### DIFF
--- a/product-approach/workflow-function/FinalizeWithError/CHANGELOG.md
+++ b/product-approach/workflow-function/FinalizeWithError/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [1.0.0] - 2025-06-03
+- Initial implementation of FinalizeWithError Lambda.
+- Handles Step Functions errors and marks verification as failed.

--- a/product-approach/workflow-function/FinalizeWithError/README.md
+++ b/product-approach/workflow-function/FinalizeWithError/README.md
@@ -1,0 +1,11 @@
+# FinalizeWithError Lambda Function
+
+This Lambda finalizes the verification workflow when an error occurs. It updates DynamoDB tables with failure status and logs details for RCA.
+
+## Overview
+- Updates `VerificationResults` with failure status and error details.
+- Optionally updates `ConversationHistory` if present.
+- Loads minimal context from `initialization.json` in S3 when available.
+- Returns a structured response used by Step Functions to terminate the workflow.
+
+See `CHANGELOG.md` for release history.

--- a/product-approach/workflow-function/FinalizeWithError/cmd/finalizewitherror/main.go
+++ b/product-approach/workflow-function/FinalizeWithError/cmd/finalizewitherror/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/lambda"
+
+	"workflow-function/FinalizeWithErrorFunction/internal/config"
+	"workflow-function/FinalizeWithErrorFunction/internal/dynamodbhelper"
+	"workflow-function/FinalizeWithErrorFunction/internal/models"
+	"workflow-function/shared/logger"
+	"workflow-function/shared/s3state"
+	"workflow-function/shared/schema"
+)
+
+var (
+	appConfig  *config.LambdaConfig
+	awsClients *config.AWSClients
+	log        logger.Logger
+)
+
+func init() {
+	log = logger.New("kootoro-verification", "FinalizeWithError")
+	var err error
+	appConfig, err = config.LoadEnvConfig()
+	if err != nil {
+		log.Error("Failed to load configuration", map[string]interface{}{"error": err.Error()})
+		os.Exit(1)
+	}
+
+	awsClients, err = config.NewAWSClients(context.Background())
+	if err != nil {
+		log.Error("Failed to initialize AWS clients", map[string]interface{}{"error": err.Error()})
+		os.Exit(1)
+	}
+}
+
+// parseStepFunctionsErrorCause parses the Step Functions cause string into a struct.
+func parseStepFunctionsErrorCause(causeString string) (*models.StepFunctionsErrorCause, error) {
+	var cause models.StepFunctionsErrorCause
+	if err := json.Unmarshal([]byte(causeString), &cause); err == nil {
+		if cause.ErrorMessage == "" {
+			cause.ErrorMessage = causeString
+		}
+		return &cause, nil
+	}
+	return &models.StepFunctionsErrorCause{ErrorMessage: causeString}, nil
+}
+
+func HandleRequest(ctx context.Context, event models.LambdaInput) (models.LambdaOutput, error) {
+	log.LogReceivedEvent(event)
+
+	var stepCause *models.StepFunctionsErrorCause
+	rawMessage := "Unknown error"
+
+	if cause, ok := event.Error["Cause"].(string); ok {
+		parsed, _ := parseStepFunctionsErrorCause(cause)
+		stepCause = parsed
+		rawMessage = parsed.ErrorMessage
+	} else if msg, ok := event.Error["ErrorMessage"].(string); ok {
+		stepCause = &models.StepFunctionsErrorCause{ErrorMessage: msg}
+		rawMessage = msg
+	} else {
+		stepCause = &models.StepFunctionsErrorCause{ErrorMessage: "Unknown error"}
+	}
+
+	var initData *schema.InitializationData
+	if ref := event.PartialS3References.InitializationS3Ref; ref.Bucket != "" && ref.Key != "" {
+		var data schema.InitializationData
+		err := s3state.GetS3ObjectAsJSON(ctx, awsClients.S3Client, ref.Bucket, ref.Key, &data)
+		if err != nil {
+			log.Warn("failed to load initialization.json", map[string]interface{}{"error": err.Error(), "bucket": ref.Bucket, "key": ref.Key})
+		} else {
+			initData = &data
+		}
+	}
+
+	err := dynamodbhelper.UpdateVerificationResultOnError(ctx, awsClients.DynamoDBClient,
+		appConfig.VerificationResultsTable, event.VerificationID, event.ErrorStage, stepCause, initData)
+	if err != nil {
+		log.Error("failed to update verification result", map[string]interface{}{"error": err.Error(), "verificationId": event.VerificationID})
+		return models.LambdaOutput{}, fmt.Errorf("critical update failure: %w", err)
+	}
+
+	if appConfig.ConversationHistoryTable != "" {
+		if err := dynamodbhelper.UpdateConversationHistoryOnError(ctx, awsClients.DynamoDBClient,
+			appConfig.ConversationHistoryTable, event.VerificationID, rawMessage); err != nil {
+			log.Warn("failed to update conversation history", map[string]interface{}{"error": err.Error(), "verificationId": event.VerificationID})
+		}
+	}
+
+	status := fmt.Sprintf("ERROR_%s", strings.ToUpper(event.ErrorStage))
+	if len(status) > 256 {
+		status = "FAILED"
+	}
+
+	output := models.LambdaOutput{
+		VerificationID: event.VerificationID,
+		Status:         status,
+		ErrorStage:     event.ErrorStage,
+		ErrorMessage:   rawMessage,
+		Message:        fmt.Sprintf("Verification failed at stage '%s'", event.ErrorStage),
+	}
+	log.LogOutputEvent(output)
+	return output, nil
+}
+
+func main() {
+	lambda.Start(HandleRequest)
+}

--- a/product-approach/workflow-function/FinalizeWithError/go.mod
+++ b/product-approach/workflow-function/FinalizeWithError/go.mod
@@ -9,3 +9,15 @@ replace workflow-function/shared/schema => ../shared/schema
 replace workflow-function/shared/s3state => ../shared/s3state
 
 replace workflow-function/shared/errors => ../shared/errors
+
+require (
+    github.com/aws/aws-lambda-go v1.48.0
+    github.com/aws/aws-sdk-go-v2 v1.36.3
+    github.com/aws/aws-sdk-go-v2/config v1.29.14
+    github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.19.0
+    github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1
+    github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3
+    workflow-function/shared/logger v0.0.0
+    workflow-function/shared/schema v0.0.0
+    workflow-function/shared/s3state v0.0.0
+)

--- a/product-approach/workflow-function/FinalizeWithError/internal/config/config.go
+++ b/product-approach/workflow-function/FinalizeWithError/internal/config/config.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// LambdaConfig holds environment configuration for the FinalizeWithError function.
+type LambdaConfig struct {
+	VerificationResultsTable string
+	ConversationHistoryTable string
+	StateManagementBucket    string
+}
+
+// LoadEnvConfig loads configuration from environment variables.
+func LoadEnvConfig() (*LambdaConfig, error) {
+	cfg := &LambdaConfig{
+		VerificationResultsTable: os.Getenv("DYNAMODB_VERIFICATION_TABLE"),
+		ConversationHistoryTable: os.Getenv("DYNAMODB_CONVERSATION_TABLE"),
+		StateManagementBucket:    os.Getenv("STATE_BUCKET"),
+	}
+
+	if cfg.VerificationResultsTable == "" {
+		return nil, fmt.Errorf("DYNAMODB_VERIFICATION_TABLE is required")
+	}
+	if cfg.StateManagementBucket == "" {
+		return nil, fmt.Errorf("STATE_BUCKET is required")
+	}
+	return cfg, nil
+}
+
+// AWSClients bundles AWS service clients used by the function.
+type AWSClients struct {
+	DynamoDBClient *dynamodb.Client
+	S3Client       *s3.Client
+}
+
+// NewAWSClients creates AWS service clients using default configuration.
+func NewAWSClients(ctx context.Context) (*AWSClients, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &AWSClients{
+		DynamoDBClient: dynamodb.NewFromConfig(cfg),
+		S3Client:       s3.NewFromConfig(cfg),
+	}, nil
+}

--- a/product-approach/workflow-function/FinalizeWithError/internal/dynamodbhelper/dynamodbhelper.go
+++ b/product-approach/workflow-function/FinalizeWithError/internal/dynamodbhelper/dynamodbhelper.go
@@ -1,0 +1,102 @@
+package dynamodbhelper
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"workflow-function/FinalizeWithErrorFunction/internal/models"
+	"workflow-function/shared/schema"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// UpdateVerificationResultOnError updates the VerificationResults table with error status and tracking info.
+func UpdateVerificationResultOnError(
+	ctx context.Context,
+	ddbClient *dynamodb.Client,
+	tableName string,
+	verificationID string,
+	errorStage string,
+	parsedErrorCause *models.StepFunctionsErrorCause,
+	initData *schema.InitializationData,
+) error {
+	currentTimestamp := time.Now().UTC().Format(time.RFC3339)
+	errorStatus := fmt.Sprintf("ERROR_%s", errorStage)
+
+	errorDetails := schema.ErrorDetails{
+		Type:    parsedErrorCause.ErrorType,
+		Message: parsedErrorCause.ErrorMessage,
+		Stage:   errorStage,
+	}
+	if len(parsedErrorCause.StackTrace) > 0 {
+		errorDetails.StackTrace = strings.Join(parsedErrorCause.StackTrace, "\n")
+	}
+
+	errorTracking := schema.ErrorTracking{
+		HasErrors:    true,
+		CurrentError: &errorDetails,
+		LastErrorAt:  currentTimestamp,
+	}
+
+	statusHistoryEntry := schema.StatusHistoryEntry{
+		Status:       errorStatus,
+		Timestamp:    currentTimestamp,
+		ErrorStage:   errorStage,
+		ErrorMessage: parsedErrorCause.ErrorMessage,
+	}
+
+	updateExpression := "SET #cs = :cs, #vs = :vs, #lua = :lua, #et = :et, #sh = list_append(if_not_exists(#sh, :empty), :entry)"
+	exprNames := map[string]string{
+		"#cs":  "currentStatus",
+		"#vs":  "verificationStatus",
+		"#lua": "lastUpdatedAt",
+		"#et":  "errorTracking",
+		"#sh":  "statusHistory",
+	}
+	marshaledTracking, err := attributevalue.MarshalMap(errorTracking)
+	if err != nil {
+		return fmt.Errorf("marshal errorTracking: %w", err)
+	}
+	marshaledEntry, err := attributevalue.MarshalMap(statusHistoryEntry)
+	if err != nil {
+		return fmt.Errorf("marshal statusHistory: %w", err)
+	}
+
+	exprValues := map[string]types.AttributeValue{
+		":cs":    &types.AttributeValueMemberS{Value: errorStatus},
+		":vs":    &types.AttributeValueMemberS{Value: "FAILED"},
+		":lua":   &types.AttributeValueMemberS{Value: currentTimestamp},
+		":et":    &types.AttributeValueMemberM{Value: marshaledTracking},
+		":entry": &types.AttributeValueMemberL{Value: []types.AttributeValue{&types.AttributeValueMemberM{Value: marshaledEntry}}},
+		":empty": &types.AttributeValueMemberL{Value: []types.AttributeValue{}},
+	}
+
+	_, err = ddbClient.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName:                 &tableName,
+		Key:                       map[string]types.AttributeValue{"verificationId": &types.AttributeValueMemberS{Value: verificationID}},
+		UpdateExpression:          &updateExpression,
+		ExpressionAttributeNames:  exprNames,
+		ExpressionAttributeValues: exprValues,
+	})
+	return err
+}
+
+// UpdateConversationHistoryOnError marks the conversation history record as failed.
+func UpdateConversationHistoryOnError(ctx context.Context, ddbClient *dynamodb.Client, tableName, verificationID, errorSummary string) error {
+	updateExpression := "SET #ts = :ts"
+	exprNames := map[string]string{"#ts": "turnStatus"}
+	exprValues := map[string]types.AttributeValue{":ts": &types.AttributeValueMemberS{Value: "FAILED_WORKFLOW"}}
+
+	_, err := ddbClient.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName:                 &tableName,
+		Key:                       map[string]types.AttributeValue{"verificationId": &types.AttributeValueMemberS{Value: verificationID}},
+		UpdateExpression:          &updateExpression,
+		ExpressionAttributeNames:  exprNames,
+		ExpressionAttributeValues: exprValues,
+	})
+	return err
+}

--- a/product-approach/workflow-function/FinalizeWithError/internal/models/models.go
+++ b/product-approach/workflow-function/FinalizeWithError/internal/models/models.go
@@ -1,0 +1,27 @@
+package models
+
+import "workflow-function/shared/schema"
+
+// StepFunctionsErrorCause represents the structured error cause from Step Functions.
+type StepFunctionsErrorCause struct {
+	ErrorMessage string   `json:"errorMessage,omitempty"`
+	ErrorType    string   `json:"errorType,omitempty"`
+	StackTrace   []string `json:"stackTrace,omitempty"`
+}
+
+// LambdaInput is the input event for the FinalizeWithError Lambda function.
+type LambdaInput struct {
+	VerificationID      string                   `json:"verificationId"`
+	Error               map[string]interface{}   `json:"error"`
+	ErrorStage          string                   `json:"errorStage"`
+	PartialS3References schema.InputS3References `json:"partialS3References"`
+}
+
+// LambdaOutput is the result returned from the FinalizeWithError Lambda.
+type LambdaOutput struct {
+	VerificationID string `json:"verificationId"`
+	Status         string `json:"status"`
+	ErrorStage     string `json:"errorStage"`
+	ErrorMessage   string `json:"errorMessage"`
+	Message        string `json:"message"`
+}

--- a/product-approach/workflow-function/shared/s3state/s3state_helpers.go
+++ b/product-approach/workflow-function/shared/s3state/s3state_helpers.go
@@ -1,0 +1,27 @@
+package s3state
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// GetS3ObjectAsJSON fetches an object from S3 and unmarshals its JSON content into target.
+func GetS3ObjectAsJSON(ctx context.Context, client *s3.Client, bucket, key string, target interface{}) error {
+	out, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return fmt.Errorf("get object: %w", err)
+	}
+	defer out.Body.Close()
+	decoder := json.NewDecoder(out.Body)
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("decode json: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- implement FinalizeWithError Lambda for error handling
- add configuration, DynamoDB helpers, and models
- add helper to load JSON from S3
- document function in README and CHANGELOG

## Testing
- `go build ./cmd/finalizewitherror` *(fails: no route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683ebf2e7fa4832da07c79dbb0d4a2bf