### PR TITLE
Add Turn1 processed path to conversation tracker

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/dynamo_manager.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"fmt"
 
 	"workflow-function/ExecuteTurn1Combined/internal/config"
 	"workflow-function/ExecuteTurn1Combined/internal/models"
@@ -35,6 +36,13 @@ func (d *DynamoManager) UpdateTurn1Completion(
 	conversationRef *models.S3Reference,
 ) bool {
 	dynamoOK := true
+
+	if processedMarkdownRef != nil && processedMarkdownRef.Key != "" {
+		if turnEntry.Metadata == nil {
+			turnEntry.Metadata = make(map[string]interface{})
+		}
+		turnEntry.Metadata["turn1ProcessedPath"] = fmt.Sprintf("s3://%s/%s", processedMarkdownRef.Bucket, processedMarkdownRef.Key)
+	}
 
 	if err := d.dynamo.UpdateVerificationStatusEnhanced(ctx, verificationID, initialVerificationAt, statusEntry); err != nil {
 		d.log.Warn("dynamodb status update failed", map[string]interface{}{

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/dynamodb.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/dynamodb.go
@@ -539,6 +539,11 @@ func (d *dynamoClient) updateConversationTurnInternal(ctx context.Context, verif
 		if conversationTracker.Metadata == nil {
 			conversationTracker.Metadata = make(map[string]interface{})
 		}
+		if turnData != nil && turnData.Metadata != nil {
+			if path, ok := turnData.Metadata["turn1ProcessedPath"].(string); ok && path != "" {
+				conversationTracker.Metadata["turn1ProcessedPath"] = path
+			}
+		}
 	} else {
 		// Initialize if not exists
 		conversationTracker = schema.ConversationTracker{
@@ -549,6 +554,11 @@ func (d *dynamoClient) updateConversationTurnInternal(ctx context.Context, verif
 			ConversationAt: schema.FormatISO8601(),
 			History:        make([]interface{}, 0),
 			Metadata:       make(map[string]interface{}),
+		}
+		if turnData != nil && turnData.Metadata != nil {
+			if path, ok := turnData.Metadata["turn1ProcessedPath"].(string); ok && path != "" {
+				conversationTracker.Metadata["turn1ProcessedPath"] = path
+			}
 		}
 	}
 
@@ -690,7 +700,7 @@ func (d *dynamoClient) updateTurn1CompletionDetailsInternal(
 				"failed to marshal processed markdown ref", true)
 		}
 		update = update.Set(expression.Name("processedTurn1MarkdownRef"), expression.Value(avRef))
-		
+
 		// Add full S3 path for turn1Processed
 		turn1ProcessedPath := fmt.Sprintf("s3://%s/%s", processedMarkdownRef.Bucket, processedMarkdownRef.Key)
 		update = update.Set(expression.Name("turn1ProcessedPath"), expression.Value(turn1ProcessedPath))


### PR DESCRIPTION
## Summary
- include turn1 processed markdown S3 path in turn metadata when updating Dynamo
- persist this path in conversation history

## Testing
- `go test ./...` *(fails: cannot load module)*

------
https://chatgpt.com/codex/tasks/task_b_683ff363afd8832d8d8987b9bc8c1fcf