### PR TITLE
Add processed path fields to ConversationTracker

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/models/shared_types.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/models/shared_types.go
@@ -206,13 +206,15 @@ func CreateVerificationContext(verificationID, verificationType string) *SchemaV
 // CreateConversationTracker creates a basic conversation tracker
 func CreateConversationTracker(verificationID string, maxTurns int) *SchemaConversationTracker {
 	return &SchemaConversationTracker{
-		ConversationId: verificationID,
-		CurrentTurn:    0,
-		MaxTurns:       maxTurns,
-		TurnStatus:     "INITIALIZED",
-		ConversationAt: FormatISO8601(),
-		History:        make([]interface{}, 0),
-		Metadata:       make(map[string]interface{}),
+		ConversationId:     verificationID,
+		CurrentTurn:        0,
+		MaxTurns:           maxTurns,
+		TurnStatus:         "INITIALIZED",
+		ConversationAt:     FormatISO8601(),
+		Turn1ProcessedPath: "",
+		Turn2ProcessedPath: "",
+		History:            make([]interface{}, 0),
+		Metadata:           make(map[string]interface{}),
 	}
 }
 
@@ -223,10 +225,10 @@ func CreateConversationTracker(verificationID string, maxTurns int) *SchemaConve
 // StepFunctionResponse represents the response structure for Step Functions
 // This matches the expected output format from the requirements
 type StepFunctionResponse struct {
-	VerificationID string                          `json:"verificationId"`
-	S3References   map[string]interface{}          `json:"s3References"`
-	Status         string                          `json:"status"`
-	Summary        map[string]interface{}          `json:"summary"`
+	VerificationID string                 `json:"verificationId"`
+	S3References   map[string]interface{} `json:"s3References"`
+	Status         string                 `json:"status"`
+	Summary        map[string]interface{} `json:"summary"`
 }
 
 // ===================================================================

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/dynamodb.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/dynamodb.go
@@ -485,13 +485,15 @@ func (d *dynamoClient) GetVerificationStatus(ctx context.Context, verificationID
 // Conversation management: InitializeConversationHistory creates initial conversation record.
 func (d *dynamoClient) InitializeConversationHistory(ctx context.Context, verificationID string, maxTurns int, metadata map[string]interface{}) error {
 	conversationTracker := &schema.ConversationTracker{
-		ConversationId: verificationID,
-		CurrentTurn:    0,
-		MaxTurns:       maxTurns,
-		TurnStatus:     "INITIALIZED",
-		ConversationAt: schema.FormatISO8601(),
-		History:        make([]interface{}, 0),
-		Metadata:       metadata,
+		ConversationId:     verificationID,
+		CurrentTurn:        0,
+		MaxTurns:           maxTurns,
+		TurnStatus:         "INITIALIZED",
+		ConversationAt:     schema.FormatISO8601(),
+		Turn1ProcessedPath: "",
+		Turn2ProcessedPath: "",
+		History:            make([]interface{}, 0),
+		Metadata:           metadata,
 	}
 
 	return d.RecordConversationHistory(ctx, conversationTracker)
@@ -542,6 +544,11 @@ func (d *dynamoClient) updateConversationTurnInternal(ctx context.Context, verif
 		if turnData != nil && turnData.Metadata != nil {
 			if path, ok := turnData.Metadata["turn1ProcessedPath"].(string); ok && path != "" {
 				conversationTracker.Metadata["turn1ProcessedPath"] = path
+				conversationTracker.Turn1ProcessedPath = path
+			}
+			if path, ok := turnData.Metadata["turn2ProcessedPath"].(string); ok && path != "" {
+				conversationTracker.Metadata["turn2ProcessedPath"] = path
+				conversationTracker.Turn2ProcessedPath = path
 			}
 		}
 	} else {
@@ -558,6 +565,11 @@ func (d *dynamoClient) updateConversationTurnInternal(ctx context.Context, verif
 		if turnData != nil && turnData.Metadata != nil {
 			if path, ok := turnData.Metadata["turn1ProcessedPath"].(string); ok && path != "" {
 				conversationTracker.Metadata["turn1ProcessedPath"] = path
+				conversationTracker.Turn1ProcessedPath = path
+			}
+			if path, ok := turnData.Metadata["turn2ProcessedPath"].(string); ok && path != "" {
+				conversationTracker.Metadata["turn2ProcessedPath"] = path
+				conversationTracker.Turn2ProcessedPath = path
 			}
 		}
 	}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/shared_types.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/models/shared_types.go
@@ -232,13 +232,15 @@ func CreateVerificationContext(verificationID, verificationType string) *SchemaV
 // CreateConversationTracker creates a basic conversation tracker
 func CreateConversationTracker(verificationID string, maxTurns int) *SchemaConversationTracker {
 	return &SchemaConversationTracker{
-		ConversationId: verificationID,
-		CurrentTurn:    0,
-		MaxTurns:       maxTurns,
-		TurnStatus:     "INITIALIZED",
-		ConversationAt: FormatISO8601(),
-		History:        make([]interface{}, 0),
-		Metadata:       make(map[string]interface{}),
+		ConversationId:     verificationID,
+		CurrentTurn:        0,
+		MaxTurns:           maxTurns,
+		TurnStatus:         "INITIALIZED",
+		ConversationAt:     FormatISO8601(),
+		Turn1ProcessedPath: "",
+		Turn2ProcessedPath: "",
+		History:            make([]interface{}, 0),
+		Metadata:           make(map[string]interface{}),
 	}
 }
 
@@ -249,10 +251,10 @@ func CreateConversationTracker(verificationID string, maxTurns int) *SchemaConve
 // StepFunctionResponse represents the response structure for Step Functions
 // This matches the expected output format from the requirements
 type StepFunctionResponse struct {
-	VerificationID string                          `json:"verificationId"`
-	S3References   map[string]interface{}          `json:"s3References"`
-	Status         string                          `json:"status"`
-	Summary        map[string]interface{}          `json:"summary"`
+	VerificationID string                 `json:"verificationId"`
+	S3References   map[string]interface{} `json:"s3References"`
+	Status         string                 `json:"status"`
+	Summary        map[string]interface{} `json:"summary"`
 }
 
 // ===================================================================

--- a/product-approach/workflow-function/shared/schema/types.go
+++ b/product-approach/workflow-function/shared/schema/types.go
@@ -15,11 +15,11 @@ type MachineStructure struct {
 
 // ImageMetadata represents image metadata from S3
 type ImageMetadata struct {
-	ContentType   string    `json:"contentType"`
-	Size          int64     `json:"size"`
-	LastModified  time.Time `json:"lastModified"`
-	ETag          string    `json:"etag"`
-	BucketOwner   string    `json:"bucketOwner"`
+	ContentType  string    `json:"contentType"`
+	Size         int64     `json:"size"`
+	LastModified time.Time `json:"lastModified"`
+	ETag         string    `json:"etag"`
+	BucketOwner  string    `json:"bucketOwner"`
 }
 
 // Images represents the image metadata structure
@@ -45,32 +45,34 @@ type TurnHistory struct {
 
 // PromptTemplate represents a prompt template
 type PromptTemplate struct {
-    TemplateId      string                 `json:"templateId"`
-    TemplateVersion string                 `json:"templateVersion"`
-    TemplateType    string                 `json:"templateType"` // "turn1-layout-vs-checking", etc.
-    Content         string                 `json:"content"`
-    Variables       map[string]interface{} `json:"variables,omitempty"`
-    CreatedAt       string                 `json:"createdAt"`
-    UpdatedAt       string                 `json:"updatedAt"`
+	TemplateId      string                 `json:"templateId"`
+	TemplateVersion string                 `json:"templateVersion"`
+	TemplateType    string                 `json:"templateType"` // "turn1-layout-vs-checking", etc.
+	Content         string                 `json:"content"`
+	Variables       map[string]interface{} `json:"variables,omitempty"`
+	CreatedAt       string                 `json:"createdAt"`
+	UpdatedAt       string                 `json:"updatedAt"`
 }
 
 // TemplateProcessor handles template processing
 type TemplateProcessor struct {
-    Template        *PromptTemplate        `json:"template"`
-    ContextData     map[string]interface{} `json:"contextData"`
-    ProcessedPrompt string                 `json:"processedPrompt"`
-    ProcessingTime  int64                  `json:"processingTimeMs"`
-    InputTokens     int                    `json:"inputTokens"`
-    OutputTokens    int                    `json:"outputTokens"`
+	Template        *PromptTemplate        `json:"template"`
+	ContextData     map[string]interface{} `json:"contextData"`
+	ProcessedPrompt string                 `json:"processedPrompt"`
+	ProcessingTime  int64                  `json:"processingTimeMs"`
+	InputTokens     int                    `json:"inputTokens"`
+	OutputTokens    int                    `json:"outputTokens"`
 }
 
 // ConversationTracker tracks conversation progress
 type ConversationTracker struct {
-    ConversationId   string                 `json:"conversationId"`
-    CurrentTurn      int                    `json:"currentTurn"`
-    MaxTurns         int                    `json:"maxTurns"`
-    TurnStatus       string                 `json:"turnStatus"`
-    ConversationAt   string                 `json:"conversationAt"`
-    History          []interface{}          `json:"history"`
-    Metadata         map[string]interface{} `json:"metadata,omitempty"`
+	ConversationId     string                 `json:"conversationId"`
+	CurrentTurn        int                    `json:"currentTurn"`
+	MaxTurns           int                    `json:"maxTurns"`
+	TurnStatus         string                 `json:"turnStatus"`
+	ConversationAt     string                 `json:"conversationAt"`
+	Turn1ProcessedPath string                 `json:"turn1ProcessedPath,omitempty"`
+	Turn2ProcessedPath string                 `json:"turn2ProcessedPath,omitempty"`
+	History            []interface{}          `json:"history"`
+	Metadata           map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/product-approach/workflow-function/shared/schema/validation.go
+++ b/product-approach/workflow-function/shared/schema/validation.go
@@ -69,8 +69,8 @@ func ValidateVerificationContext(ctx *VerificationContext) Errors {
 		errors = append(errors, ValidationError{Field: "verificationType", Message: "required field missing"})
 	} else {
 		// Validate verification type
-		if ctx.VerificationType != VerificationTypeLayoutVsChecking && 
-		   ctx.VerificationType != VerificationTypePreviousVsCurrent {
+		if ctx.VerificationType != VerificationTypeLayoutVsChecking &&
+			ctx.VerificationType != VerificationTypePreviousVsCurrent {
 			errors = append(errors, ValidationError{
 				Field:   "verificationType",
 				Message: "must be either LAYOUT_VS_CHECKING or PREVIOUS_VS_CURRENT",
@@ -91,7 +91,7 @@ func ValidateVerificationContext(ctx *VerificationContext) Errors {
 	if ctx.VerificationType == VerificationTypeLayoutVsChecking {
 		if ctx.LayoutId == 0 {
 			errors = append(errors, ValidationError{
-				Field:   "layoutId", 
+				Field:   "layoutId",
 				Message: "required for LAYOUT_VS_CHECKING verification type",
 			})
 		}
@@ -115,8 +115,8 @@ func ValidateWorkflowState(state *WorkflowState) Errors {
 		state.SchemaVersion = SchemaVersion
 	} else if state.SchemaVersion != SchemaVersion {
 		errors = append(errors, ValidationError{
-			Field:   "schemaVersion", 
-			Message: fmt.Sprintf("unsupported schema version: %s (supported: %s)", 
+			Field: "schemaVersion",
+			Message: fmt.Sprintf("unsupported schema version: %s (supported: %s)",
 				state.SchemaVersion, SchemaVersion),
 		})
 	}
@@ -164,12 +164,12 @@ func ValidateWorkflowState(state *WorkflowState) Errors {
 // ValidateImageInfo validates image information including S3 storage for Base64 data
 func ValidateImageInfo(img *ImageInfo, requireBase64 bool) Errors {
 	var errors Errors
-	
+
 	if img == nil {
 		errors = append(errors, ValidationError{Field: "imageInfo", Message: "cannot be nil"})
 		return errors
 	}
-	
+
 	// Basic validations
 	if img.URL == "" {
 		errors = append(errors, ValidationError{Field: "url", Message: "required"})
@@ -180,7 +180,7 @@ func ValidateImageInfo(img *ImageInfo, requireBase64 bool) Errors {
 	if img.S3Bucket == "" {
 		errors = append(errors, ValidationError{Field: "s3Bucket", Message: "required"})
 	}
-	
+
 	// Base64 validation when required
 	if requireBase64 {
 		// Check for S3 storage of Base64 data
@@ -190,7 +190,7 @@ func ValidateImageInfo(img *ImageInfo, requireBase64 bool) Errors {
 		if img.Format == "" {
 			errors = append(errors, ValidationError{Field: "format", Message: "required for Base64 data"})
 		}
-		
+
 		// Validate supported formats
 		supportedFormats := []string{"png", "jpeg", "jpg"}
 		formatSupported := false
@@ -202,11 +202,11 @@ func ValidateImageInfo(img *ImageInfo, requireBase64 bool) Errors {
 		}
 		if !formatSupported {
 			errors = append(errors, ValidationError{
-				Field:   "format", 
+				Field:   "format",
 				Message: fmt.Sprintf("unsupported format: %s (supported: %v)", img.Format, supportedFormats),
 			})
 		}
-		
+
 		// Validate Base64 size
 		if err := img.ValidateBase64Size(); err != nil {
 			errors = append(errors, ValidationError{
@@ -215,19 +215,19 @@ func ValidateImageInfo(img *ImageInfo, requireBase64 bool) Errors {
 			})
 		}
 	}
-	
+
 	return errors
 }
 
 // ValidateImageData validates the complete ImageData structure
 func ValidateImageData(images *ImageData, requireBase64 bool) Errors {
 	var errors Errors
-	
+
 	if images == nil {
 		errors = append(errors, ValidationError{Field: "images", Message: "cannot be nil"})
 		return errors
 	}
-	
+
 	// Validate reference image
 	if images.Reference == nil {
 		errors = append(errors, ValidationError{Field: "reference", Message: "required"})
@@ -240,7 +240,7 @@ func ValidateImageData(images *ImageData, requireBase64 bool) Errors {
 			})
 		}
 	}
-	
+
 	// Validate checking image
 	if images.Checking == nil {
 		errors = append(errors, ValidationError{Field: "checking", Message: "required"})
@@ -253,7 +253,7 @@ func ValidateImageData(images *ImageData, requireBase64 bool) Errors {
 			})
 		}
 	}
-	
+
 	// Validate Base64 generation flag consistency
 	if requireBase64 && !images.Base64Generated {
 		errors = append(errors, ValidationError{
@@ -261,23 +261,23 @@ func ValidateImageData(images *ImageData, requireBase64 bool) Errors {
 			Message: "must be true when Base64 data is required",
 		})
 	}
-	
+
 	return errors
 }
 
 // ValidateBedrockMessages validates Bedrock message format according to schema v2.0.0
 func ValidateBedrockMessages(messages []BedrockMessage) Errors {
 	var errors Errors
-	
+
 	if len(messages) == 0 {
 		errors = append(errors, ValidationError{Field: "messages", Message: "at least one message required"})
 		return errors
 	}
-	
+
 	for i, msg := range messages {
 		if msg.Role == "" {
 			errors = append(errors, ValidationError{
-				Field:   fmt.Sprintf("messages[%d].role", i), 
+				Field:   fmt.Sprintf("messages[%d].role", i),
 				Message: "required",
 			})
 		} else if msg.Role != "user" && msg.Role != "assistant" {
@@ -286,14 +286,14 @@ func ValidateBedrockMessages(messages []BedrockMessage) Errors {
 				Message: "must be 'user' or 'assistant'",
 			})
 		}
-		
+
 		if len(msg.Content) == 0 {
 			errors = append(errors, ValidationError{
-				Field:   fmt.Sprintf("messages[%d].content", i), 
+				Field:   fmt.Sprintf("messages[%d].content", i),
 				Message: "at least one content item required",
 			})
 		}
-		
+
 		hasText := false
 		for j, content := range msg.Content {
 			if content.Type == "" {
@@ -307,7 +307,7 @@ func ValidateBedrockMessages(messages []BedrockMessage) Errors {
 					Message: "must be 'text' or 'image'",
 				})
 			}
-			
+
 			if content.Type == "text" {
 				hasText = true
 				if content.Text == "" {
@@ -317,7 +317,7 @@ func ValidateBedrockMessages(messages []BedrockMessage) Errors {
 					})
 				}
 			}
-			
+
 			if content.Type == "image" {
 				if content.Image == nil {
 					errors = append(errors, ValidationError{
@@ -338,7 +338,7 @@ func ValidateBedrockMessages(messages []BedrockMessage) Errors {
 							Message: "must be 'base64'",
 						})
 					}
-					
+
 					if content.Image.Source.Media_type == "" {
 						errors = append(errors, ValidationError{
 							Field:   fmt.Sprintf("messages[%d].content[%d].image.source.media_type", i, j),
@@ -360,7 +360,7 @@ func ValidateBedrockMessages(messages []BedrockMessage) Errors {
 							})
 						}
 					}
-					
+
 					if content.Image.Source.Data == "" {
 						errors = append(errors, ValidationError{
 							Field:   fmt.Sprintf("messages[%d].content[%d].image.source.data", i, j),
@@ -370,7 +370,7 @@ func ValidateBedrockMessages(messages []BedrockMessage) Errors {
 				}
 			}
 		}
-		
+
 		// Ensure each message has at least one text content
 		if !hasText {
 			errors = append(errors, ValidationError{
@@ -379,23 +379,23 @@ func ValidateBedrockMessages(messages []BedrockMessage) Errors {
 			})
 		}
 	}
-	
+
 	return errors
 }
 
 // ValidateCurrentPrompt validates the CurrentPrompt structure
 func ValidateCurrentPrompt(prompt *CurrentPrompt, requireMessages bool) Errors {
 	var errors Errors
-	
+
 	if prompt == nil {
 		errors = append(errors, ValidationError{Field: "currentPrompt", Message: "cannot be nil"})
 		return errors
 	}
-	
+
 	if prompt.TurnNumber <= 0 {
 		errors = append(errors, ValidationError{Field: "turnNumber", Message: "must be greater than 0"})
 	}
-	
+
 	if prompt.IncludeImage == "" {
 		errors = append(errors, ValidationError{Field: "includeImage", Message: "required"})
 	} else {
@@ -413,7 +413,7 @@ func ValidateCurrentPrompt(prompt *CurrentPrompt, requireMessages bool) Errors {
 			})
 		}
 	}
-	
+
 	// Validate messages if required (for Bedrock API calls)
 	if requireMessages {
 		if len(prompt.Messages) == 0 {
@@ -423,32 +423,32 @@ func ValidateCurrentPrompt(prompt *CurrentPrompt, requireMessages bool) Errors {
 			errors = append(errors, msgErrors...)
 		}
 	}
-	
+
 	// Backward compatibility: validate text prompt if messages are not present
 	if len(prompt.Messages) == 0 && prompt.Text == "" {
 		errors = append(errors, ValidationError{Field: "text", Message: "required when messages are not provided"})
 	}
-	
+
 	return errors
 }
 
 // ValidateBedrockConfig validates the Bedrock configuration
 func ValidateBedrockConfig(config *BedrockConfig) Errors {
 	var errors Errors
-	
+
 	if config == nil {
 		errors = append(errors, ValidationError{Field: "bedrockConfig", Message: "cannot be nil"})
 		return errors
 	}
-	
+
 	if config.AnthropicVersion == "" {
 		errors = append(errors, ValidationError{Field: "anthropicVersion", Message: "required"})
 	}
-	
+
 	if config.MaxTokens <= 0 {
 		errors = append(errors, ValidationError{Field: "maxTokens", Message: "must be greater than 0"})
 	}
-	
+
 	// Validate thinking configuration if present
 	if config.Thinking != nil {
 		if config.Thinking.Type == "" {
@@ -458,76 +458,77 @@ func ValidateBedrockConfig(config *BedrockConfig) Errors {
 			errors = append(errors, ValidationError{Field: "thinking.budgetTokens", Message: "must be greater than 0"})
 		}
 	}
-	
+
 	return errors
 }
+
 // Add these validation functions for new structures
 
 // ValidateStatusHistoryEntry validates status history entries
 func ValidateStatusHistoryEntry(entry *StatusHistoryEntry) Errors {
-    var errors Errors
-    
-    if entry == nil {
-        errors = append(errors, ValidationError{Field: "statusHistoryEntry", Message: "cannot be nil"})
-        return errors
-    }
-    
-    if entry.Status == "" {
-        errors = append(errors, ValidationError{Field: "status", Message: "required"})
-    }
-    
-    if entry.Timestamp == "" {
-        errors = append(errors, ValidationError{Field: "timestamp", Message: "required"})
-    }
-    
-    if entry.FunctionName == "" {
-        errors = append(errors, ValidationError{Field: "functionName", Message: "required"})
-    }
-    
-    return errors
+	var errors Errors
+
+	if entry == nil {
+		errors = append(errors, ValidationError{Field: "statusHistoryEntry", Message: "cannot be nil"})
+		return errors
+	}
+
+	if entry.Status == "" {
+		errors = append(errors, ValidationError{Field: "status", Message: "required"})
+	}
+
+	if entry.Timestamp == "" {
+		errors = append(errors, ValidationError{Field: "timestamp", Message: "required"})
+	}
+
+	if entry.FunctionName == "" {
+		errors = append(errors, ValidationError{Field: "functionName", Message: "required"})
+	}
+
+	return errors
 }
 
 // ValidateProcessingMetrics validates processing metrics
 func ValidateProcessingMetrics(metrics *ProcessingMetrics) Errors {
-    var errors Errors
-    
-    if metrics == nil {
-        return errors // Optional field
-    }
-    
-    // Add specific validations for metrics
-    if metrics.WorkflowTotal != nil {
-        if metrics.WorkflowTotal.TotalTimeMs < 0 {
-            errors = append(errors, ValidationError{Field: "workflowTotal.totalTimeMs", Message: "cannot be negative"})
-        }
-    }
-    
-    return errors
+	var errors Errors
+
+	if metrics == nil {
+		return errors // Optional field
+	}
+
+	// Add specific validations for metrics
+	if metrics.WorkflowTotal != nil {
+		if metrics.WorkflowTotal.TotalTimeMs < 0 {
+			errors = append(errors, ValidationError{Field: "workflowTotal.totalTimeMs", Message: "cannot be negative"})
+		}
+	}
+
+	return errors
 }
 
 // ValidateErrorTracking validates error tracking structure
 func ValidateErrorTracking(tracking *ErrorTracking) Errors {
-    var errors Errors
-    
-    if tracking == nil {
-        return errors // Optional field
-    }
-    
-    if tracking.RecoveryAttempts < 0 {
-        errors = append(errors, ValidationError{Field: "recoveryAttempts", Message: "cannot be negative"})
-    }
-    
-    return errors
+	var errors Errors
+
+	if tracking == nil {
+		return errors // Optional field
+	}
+
+	if tracking.RecoveryAttempts < 0 {
+		errors = append(errors, ValidationError{Field: "recoveryAttempts", Message: "cannot be negative"})
+	}
+
+	return errors
 }
 
 // ValidateTemplateProcessor validates template processor structure
 func ValidateTemplateProcessor(processor *TemplateProcessor) Errors {
 	var errors Errors
-	
+
 	if processor == nil {
 		return errors // Optional field
 	}
-	
+
 	if processor.Template != nil {
 		if processor.Template.TemplateId == "" {
 			errors = append(errors, ValidationError{Field: "template.templateId", Message: "required"})
@@ -536,73 +537,81 @@ func ValidateTemplateProcessor(processor *TemplateProcessor) Errors {
 			errors = append(errors, ValidationError{Field: "template.content", Message: "required"})
 		}
 	}
-	
+
 	if processor.ProcessingTime < 0 {
 		errors = append(errors, ValidationError{Field: "processingTime", Message: "cannot be negative"})
 	}
-	
+
 	return errors
 }
 
 // ValidateCombinedTurnResponse validates combined turn response structure
 func ValidateCombinedTurnResponse(response *CombinedTurnResponse) Errors {
 	var errors Errors
-	
+
 	if response == nil {
 		errors = append(errors, ValidationError{Field: "combinedTurnResponse", Message: "cannot be nil"})
 		return errors
 	}
-	
+
 	// Validate embedded TurnResponse
 	if response.TurnResponse != nil {
 		if response.TurnResponse.TurnId <= 0 {
 			errors = append(errors, ValidationError{Field: "turnId", Message: "must be greater than 0"})
 		}
 	}
-	
+
 	// Validate processing stages
 	for i, stage := range response.ProcessingStages {
 		if stage.StageName == "" {
 			errors = append(errors, ValidationError{
-				Field: fmt.Sprintf("processingStages[%d].stageName", i), 
+				Field:   fmt.Sprintf("processingStages[%d].stageName", i),
 				Message: "required",
 			})
 		}
 		if stage.Duration < 0 {
 			errors = append(errors, ValidationError{
-				Field: fmt.Sprintf("processingStages[%d].duration", i), 
+				Field:   fmt.Sprintf("processingStages[%d].duration", i),
 				Message: "cannot be negative",
 			})
 		}
 	}
-	
+
 	return errors
 }
 
 // ValidateConversationTracker validates conversation tracker structure
 func ValidateConversationTracker(tracker *ConversationTracker) Errors {
 	var errors Errors
-	
+
 	if tracker == nil {
 		return errors // Optional field
 	}
-	
+
 	if tracker.ConversationId == "" {
 		errors = append(errors, ValidationError{Field: "conversationId", Message: "required"})
 	}
-	
+
 	if tracker.CurrentTurn < 0 {
 		errors = append(errors, ValidationError{Field: "currentTurn", Message: "cannot be negative"})
 	}
-	
+
 	if tracker.MaxTurns <= 0 {
 		errors = append(errors, ValidationError{Field: "maxTurns", Message: "must be greater than 0"})
 	}
-	
+
 	if tracker.CurrentTurn > tracker.MaxTurns {
 		errors = append(errors, ValidationError{Field: "currentTurn", Message: "cannot exceed maxTurns"})
 	}
-	
+
+	if tracker.Turn1ProcessedPath != "" && !strings.HasPrefix(tracker.Turn1ProcessedPath, "s3://") {
+		errors = append(errors, ValidationError{Field: "turn1ProcessedPath", Message: "must start with s3://"})
+	}
+
+	if tracker.Turn2ProcessedPath != "" && !strings.HasPrefix(tracker.Turn2ProcessedPath, "s3://") {
+		errors = append(errors, ValidationError{Field: "turn2ProcessedPath", Message: "must start with s3://"})
+	}
+
 	return errors
 }
 
@@ -610,11 +619,11 @@ func ValidateConversationTracker(tracker *ConversationTracker) Errors {
 func ValidateVerificationContextEnhanced(ctx *VerificationContext) Errors {
 	// Start with existing validation
 	errors := ValidateVerificationContext(ctx)
-	
+
 	if ctx == nil {
 		return errors
 	}
-	
+
 	// Validate new fields
 	if len(ctx.StatusHistory) > 0 {
 		for i, entry := range ctx.StatusHistory {
@@ -627,7 +636,7 @@ func ValidateVerificationContextEnhanced(ctx *VerificationContext) Errors {
 			}
 		}
 	}
-	
+
 	if ctx.ProcessingMetrics != nil {
 		metricErrors := ValidateProcessingMetrics(ctx.ProcessingMetrics)
 		for _, err := range metricErrors {
@@ -637,7 +646,7 @@ func ValidateVerificationContextEnhanced(ctx *VerificationContext) Errors {
 			})
 		}
 	}
-	
+
 	if ctx.ErrorTracking != nil {
 		trackingErrors := ValidateErrorTracking(ctx.ErrorTracking)
 		for _, err := range trackingErrors {
@@ -647,93 +656,93 @@ func ValidateVerificationContextEnhanced(ctx *VerificationContext) Errors {
 			})
 		}
 	}
-	
+
 	return errors
 }
 
 // ADD: New validation functions
 func ValidateConversationHistory(ch *ConversationHistory) Errors {
-    var errors Errors
-    
-    if ch == nil {
-        errors = append(errors, ValidationError{Field: "conversationHistory", Message: "cannot be nil"})
-        return errors
-    }
-    
-    if ch.VerificationId == "" {
-        errors = append(errors, ValidationError{Field: "verificationId", Message: "required"})
-    }
-    
-    if ch.ConversationAt == "" {
-        errors = append(errors, ValidationError{Field: "conversationAt", Message: "required"})
-    }
-    
-    if ch.CurrentTurn < 0 || ch.CurrentTurn > ch.MaxTurns {
-        errors = append(errors, ValidationError{Field: "currentTurn", Message: "invalid turn number"})
-    }
-    
-    // Validate turn status
-    validTurnStatuses := []string{TurnStatusActive, TurnStatusCompleted, TurnStatusFailed}
-    if !contains(validTurnStatuses, ch.TurnStatus) {
-        errors = append(errors, ValidationError{Field: "turnStatus", Message: "invalid turn status"})
-    }
-    
-    return errors
+	var errors Errors
+
+	if ch == nil {
+		errors = append(errors, ValidationError{Field: "conversationHistory", Message: "cannot be nil"})
+		return errors
+	}
+
+	if ch.VerificationId == "" {
+		errors = append(errors, ValidationError{Field: "verificationId", Message: "required"})
+	}
+
+	if ch.ConversationAt == "" {
+		errors = append(errors, ValidationError{Field: "conversationAt", Message: "required"})
+	}
+
+	if ch.CurrentTurn < 0 || ch.CurrentTurn > ch.MaxTurns {
+		errors = append(errors, ValidationError{Field: "currentTurn", Message: "invalid turn number"})
+	}
+
+	// Validate turn status
+	validTurnStatuses := []string{TurnStatusActive, TurnStatusCompleted, TurnStatusFailed}
+	if !contains(validTurnStatuses, ch.TurnStatus) {
+		errors = append(errors, ValidationError{Field: "turnStatus", Message: "invalid turn status"})
+	}
+
+	return errors
 }
 
 func ValidateVerificationResults(vr *VerificationResults) Errors {
-    var errors Errors
-    
-    if vr == nil {
-        errors = append(errors, ValidationError{Field: "verificationResults", Message: "cannot be nil"})
-        return errors
-    }
-    
-    if vr.VerificationId == "" {
-        errors = append(errors, ValidationError{Field: "verificationId", Message: "required"})
-    }
-    
-    if vr.VerificationAt == "" {
-        errors = append(errors, ValidationError{Field: "verificationAt", Message: "required"})
-    }
-    
-    // Validate verification type
-    validTypes := []string{VerificationTypeLayoutVsChecking, VerificationTypePreviousVsCurrent}
-    if !contains(validTypes, vr.VerificationType) {
-        errors = append(errors, ValidationError{Field: "verificationType", Message: "invalid verification type"})
-    }
-    
-    // Validate verification status
-    validStatuses := []string{VerificationStatusCorrect, VerificationStatusIncorrect, VerificationStatusPartial, VerificationStatusFailed}
-    if !contains(validStatuses, vr.VerificationStatus) {
-        errors = append(errors, ValidationError{Field: "verificationStatus", Message: "invalid verification status"})
-    }
-    
-    // Type-specific validations
-    if vr.VerificationType == VerificationTypeLayoutVsChecking {
-        if vr.LayoutId == 0 {
-            errors = append(errors, ValidationError{Field: "layoutId", Message: "required for layout verification"})
-        }
-        if vr.LayoutPrefix == "" {
-            errors = append(errors, ValidationError{Field: "layoutPrefix", Message: "required for layout verification"})
-        }
-    }
-    
-    if vr.VerificationType == VerificationTypePreviousVsCurrent {
-        if vr.PreviousVerificationId == "" {
-            errors = append(errors, ValidationError{Field: "previousVerificationId", Message: "required for temporal verification"})
-        }
-    }
-    
-    return errors
+	var errors Errors
+
+	if vr == nil {
+		errors = append(errors, ValidationError{Field: "verificationResults", Message: "cannot be nil"})
+		return errors
+	}
+
+	if vr.VerificationId == "" {
+		errors = append(errors, ValidationError{Field: "verificationId", Message: "required"})
+	}
+
+	if vr.VerificationAt == "" {
+		errors = append(errors, ValidationError{Field: "verificationAt", Message: "required"})
+	}
+
+	// Validate verification type
+	validTypes := []string{VerificationTypeLayoutVsChecking, VerificationTypePreviousVsCurrent}
+	if !contains(validTypes, vr.VerificationType) {
+		errors = append(errors, ValidationError{Field: "verificationType", Message: "invalid verification type"})
+	}
+
+	// Validate verification status
+	validStatuses := []string{VerificationStatusCorrect, VerificationStatusIncorrect, VerificationStatusPartial, VerificationStatusFailed}
+	if !contains(validStatuses, vr.VerificationStatus) {
+		errors = append(errors, ValidationError{Field: "verificationStatus", Message: "invalid verification status"})
+	}
+
+	// Type-specific validations
+	if vr.VerificationType == VerificationTypeLayoutVsChecking {
+		if vr.LayoutId == 0 {
+			errors = append(errors, ValidationError{Field: "layoutId", Message: "required for layout verification"})
+		}
+		if vr.LayoutPrefix == "" {
+			errors = append(errors, ValidationError{Field: "layoutPrefix", Message: "required for layout verification"})
+		}
+	}
+
+	if vr.VerificationType == VerificationTypePreviousVsCurrent {
+		if vr.PreviousVerificationId == "" {
+			errors = append(errors, ValidationError{Field: "previousVerificationId", Message: "required for temporal verification"})
+		}
+	}
+
+	return errors
 }
 
 // Helper function
 func contains(slice []string, item string) bool {
-    for _, s := range slice {
-        if s == item {
-            return true
-        }
-    }
-    return false
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- support processed path tracking for turns
- validate `turn1ProcessedPath` and `turn2ProcessedPath` fields
- initialize fields in conversation tracker creators
- set processed paths during conversation updates

## Testing
- `go vet ./...` *(fails: cannot load module)*

------
https://chatgpt.com/codex/tasks/task_b_683ff57fb454832da22ffa01e1c62c05