### PR TITLE
Remove vendingMachineId validation

### DIFF
--- a/product-approach/workflow-function/FetchHistoricalVerification/README.md
+++ b/product-approach/workflow-function/FetchHistoricalVerification/README.md
@@ -84,8 +84,7 @@ The Lambda function expects input in the following format:
     "verificationType": "PREVIOUS_VS_CURRENT",
     "referenceImageUrl": "s3://kootoro-checking-bucket/2025-04-20/VM-3245/check_10-00-00.jpg",
     "checkingImageUrl": "s3://kootoro-checking-bucket/2025-04-21/VM-3245/check_15-30-25.jpg",
-    "previousVerificationId": "verif-2025042010000000",
-    "vendingMachineId": "VM-3245"
+    "previousVerificationId": "verif-2025042010000000"
   }
 }
 ```
@@ -97,7 +96,6 @@ The Lambda function expects input in the following format:
 - `referenceImageUrl` - S3 URI of the reference image (previous checking image)
 - `checkingImageUrl` - S3 URI of the current checking image
 - `previousVerificationId` - ID of the previous verification to retrieve
-- `vendingMachineId` - ID of the vending machine being verified
 
 ## Output Format
 

--- a/product-approach/workflow-function/FetchHistoricalVerification/cmd/main.go
+++ b/product-approach/workflow-function/FetchHistoricalVerification/cmd/main.go
@@ -17,7 +17,7 @@ import (
 func handler(ctx context.Context, event internal.InputEvent) (internal.OutputEvent, error) {
 	// Load config first
 	cfg := internal.LoadConfig()
-	
+
 	// Initialize dependencies
 	deps, err := initDependencies(ctx, cfg)
 	if err != nil {
@@ -99,10 +99,6 @@ func validateInput(ctx schema.VerificationContext) error {
 
 	if ctx.CheckingImageUrl == "" {
 		return errors.NewMissingFieldError("checkingImageUrl")
-	}
-
-	if ctx.VendingMachineId == "" {
-		return errors.NewMissingFieldError("vendingMachineId")
 	}
 
 	// Verify S3 URL format for reference image

--- a/product-approach/workflow-function/shared/schema/validation.go
+++ b/product-approach/workflow-function/shared/schema/validation.go
@@ -83,9 +83,6 @@ func ValidateVerificationContext(ctx *VerificationContext) Errors {
 	if ctx.CheckingImageUrl == "" {
 		errors = append(errors, ValidationError{Field: "checkingImageUrl", Message: "required field missing"})
 	}
-	if ctx.VendingMachineId == "" {
-		errors = append(errors, ValidationError{Field: "vendingMachineId", Message: "required field missing"})
-	}
 
 	// Verification type-specific validations
 	if ctx.VerificationType == VerificationTypeLayoutVsChecking {


### PR DESCRIPTION
## Summary
- make `vendingMachineId` optional in schema validation and lambda input check
- update documentation for `FetchHistoricalVerification` accordingly

## Testing
- `go test ./...` *(fails: Forbidden)*
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_683ff9bf6700832d80408eba9aa387bc