### PR TITLE
Make DynamoDB retry attempts configurable

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/config/config.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/config/config.go
@@ -71,7 +71,7 @@ func LoadConfiguration() (*Config, error) {
 	cfg.Processing.BudgetTokens = getInt("BUDGET_TOKENS", 16000)
 	cfg.Processing.ThinkingType = getEnv("THINKING_TYPE", "disabled")
 	cfg.Processing.Temperature = getFloat("TEMPERATURE", 0.7)
-	cfg.Processing.MaxRetries = getInt("MAX_RETRIES", 3)
+	cfg.Processing.MaxRetries = getInt("MAX_RETRIES", 1)
 	cfg.Processing.BedrockConnectTimeoutSec = getInt("BEDROCK_CONNECT_TIMEOUT_SEC", 10)
 	cfg.Processing.BedrockCallTimeoutSec = getInt("BEDROCK_CALL_TIMEOUT_SEC", 30)
 

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/dynamodb.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/dynamodb.go
@@ -75,6 +75,7 @@ type dynamoClient struct {
 	conversationTable string
 	layoutTable       string
 	region            string
+	maxRetries        int
 }
 
 // NewDynamoDBService constructs an enhanced DynamoDBService with comprehensive capabilities.
@@ -86,12 +87,17 @@ func NewDynamoDBService(cfg *config.Config) (DynamoDBService, error) {
 			WithContext("region", cfg.AWS.Region)
 	}
 	client := dynamodb.NewFromConfig(awsCfg)
+	maxRetries := cfg.Processing.MaxRetries
+	if maxRetries <= 0 {
+		maxRetries = 1
+	}
 	return &dynamoClient{
 		client:            client,
 		verificationTable: cfg.AWS.DynamoDBVerificationTable,
 		conversationTable: cfg.AWS.DynamoDBConversationTable,
 		layoutTable:       "LayoutMetadata", // Would be configurable in real implementation
 		region:            cfg.AWS.Region,
+		maxRetries:        maxRetries,
 	}, nil
 }
 
@@ -871,7 +877,11 @@ func (d *dynamoClient) getVerificationResultsKey(verificationID, verificationAt 
 
 // retryWithBackoff executes a DynamoDB operation with exponential backoff retry logic
 func (d *dynamoClient) retryWithBackoff(ctx context.Context, operation func() error, operationName string) error {
-	maxAttempts := 5
+	maxAttempts := d.maxRetries
+	if maxAttempts <= 0 {
+		maxAttempts = 1
+	}
+	log.Printf("DynamoDB operation %s will retry up to %d times", operationName, maxAttempts)
 	baseDelay := 200 * time.Millisecond
 	maxDelay := 5 * time.Second
 	backoffMultiple := 2.0

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
@@ -74,7 +74,7 @@ func LoadConfiguration() (*Config, error) {
 	cfg.Processing.BudgetTokens = getInt("BUDGET_TOKENS", 16000)
 	cfg.Processing.ThinkingType = getEnv("THINKING_TYPE", "enable")
 	cfg.Processing.Temperature = getFloat("TEMPERATURE", 0.7)
-	cfg.Processing.MaxRetries = getInt("MAX_RETRIES", 3)
+	cfg.Processing.MaxRetries = getInt("MAX_RETRIES", 1)
 	cfg.Processing.BedrockConnectTimeoutSec = getInt("BEDROCK_CONNECT_TIMEOUT_SEC", 10)
 	cfg.Processing.BedrockCallTimeoutSec = getInt("BEDROCK_CALL_TIMEOUT_SEC", 30)
 	cfg.Processing.DiscrepancyThreshold = getInt("DISCREPANCY_THRESHOLD", 5)


### PR DESCRIPTION
## Summary
- expose maxRetries on dynamo client and set from config
- default MAX_RETRIES env var to 1
- use configured attempt count in retry logs

## Testing
- `GOWORK=off go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_683fff140f14832d9bf97d68e8fcae15