### PR TITLE
Update DynamoDB retry configuration

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the ExecuteTurn1Combined function will be documented in this file.
 
+## [2.8.7] - 2025-06-05
+### Changed
+- `NewDynamoDBService` now configures the AWS SDK with adaptive retry mode
+  and honors `cfg.Processing.MaxRetries`.
+
 ## [2.8.6] - 2025-06-04
 ### Added
 - **Full S3 Path Storage in DynamoDB**: Added storage of complete S3 paths for turn1Processed responses

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/dynamodb.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/dynamodb.go
@@ -80,7 +80,12 @@ type dynamoClient struct {
 
 // NewDynamoDBService constructs an enhanced DynamoDBService with comprehensive capabilities.
 func NewDynamoDBService(cfg *config.Config) (DynamoDBService, error) {
-	awsCfg, err := awsconfig.LoadDefaultConfig(context.Background(), awsconfig.WithRegion(cfg.AWS.Region))
+	awsCfg, err := awsconfig.LoadDefaultConfig(
+		context.Background(),
+		awsconfig.WithRegion(cfg.AWS.Region),
+		awsconfig.WithRetryMaxAttempts(cfg.Processing.MaxRetries),
+		awsconfig.WithRetryMode(aws.RetryModeAdaptive),
+	)
 	if err != nil {
 		return nil, errors.WrapError(err, errors.ErrorTypeInternal,
 			"failed to load AWS config for DynamoDB", false).

--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.2.18] - 2025-06-05
+### Changed
+- `NewDynamoDBService` now configures the AWS SDK with adaptive retry mode
+  and honors `cfg.Processing.MaxRetries`.
+
 ## [2.2.17] - 2025-06-04
 ### Removed
 - Layout dimension warnings for Turn2 were removed from the prompt generation logic.

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go
@@ -82,7 +82,12 @@ type dynamoClient struct {
 
 // NewDynamoDBService constructs an enhanced DynamoDBService with comprehensive capabilities.
 func NewDynamoDBService(cfg *config.Config) (DynamoDBService, error) {
-	awsCfg, err := awsconfig.LoadDefaultConfig(context.Background(), awsconfig.WithRegion(cfg.AWS.Region))
+	awsCfg, err := awsconfig.LoadDefaultConfig(
+		context.Background(),
+		awsconfig.WithRegion(cfg.AWS.Region),
+		awsconfig.WithRetryMaxAttempts(cfg.Processing.MaxRetries),
+		awsconfig.WithRetryMode(aws.RetryModeAdaptive),
+	)
 	if err != nil {
 		return nil, errors.WrapError(err, errors.ErrorTypeInternal,
 			"failed to load AWS config for DynamoDB", false).


### PR DESCRIPTION
## Summary
- configure adaptive retry settings in `NewDynamoDBService`
- document the change in each module's changelog

## Testing
- `go test ./...` *(fails: cannot load module)*

------
https://chatgpt.com/codex/tasks/task_b_684000550d90832d9d2333e69e77341f