### PR TITLE
Fix Turn1Response validation mismatch

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3_turn2.go
@@ -266,7 +266,7 @@ func (m *s3Manager) LoadTurn1SchemaResponse(ctx context.Context, ref models.S3Re
 
 	// If prompt or response content is empty, attempt to recover from
 	// conversation history when provided
-        if (resp.Prompt == "" || resp.Response.Content == "") && conversationRef != nil && conversationRef.Key != "" {
+	if (resp.Prompt == "" || resp.Response.Content == "") && conversationRef != nil && conversationRef.Key != "" {
 		var conv struct {
 			Messages []schema.BedrockMessage `json:"messages"`
 		}
@@ -310,28 +310,58 @@ func (m *s3Manager) LoadTurn1SchemaResponse(ctx context.Context, ref models.S3Re
 				"bucket": conversationRef.Bucket,
 				"key":    conversationRef.Key,
 			})
-                }
-        }
+		}
+	}
 
-        // Validate the loaded Turn1 response to ensure required fields are present
-        if err := bedrock.ValidateTurn1Response(&resp); err != nil {
-                m.logger.Error("turn1_schema_validation_failed", map[string]interface{}{
-                        "error":  err.Error(),
-                        "bucket": ref.Bucket,
-                        "key":    ref.Key,
-                })
-                return nil, &errors.WorkflowError{
-                        Type:      errors.ErrorTypeValidation,
-                        Code:      "InvalidTurn1Response",
-                        Message:   err.Error(),
-                        Retryable: false,
-                        Severity:  errors.ErrorSeverityCritical,
-                        APISource: errors.APISourceUnknown,
-                        Timestamp: time.Now(),
-                }
-        }
+	// Validate the loaded Turn1 response to ensure required fields are present
+	// Convert schema.TurnResponse to bedrock.Turn1Response for validation
+	bResp := bedrock.Turn1Response{
+		TurnID:    resp.TurnId,
+		Timestamp: resp.Timestamp,
+		Prompt:    resp.Prompt,
+		Response: bedrock.TextResponse{
+			Content:    resp.Response.Content,
+			StopReason: resp.Response.StopReason,
+			Thinking:   resp.Response.Thinking,
+		},
+		Thinking:      resp.Response.Thinking,
+		LatencyMs:     resp.LatencyMs,
+		AnalysisStage: resp.Stage,
+		BedrockMetadata: bedrock.BedrockMetadata{
+			ModelID:         resp.Response.ModelId,
+			RequestID:       resp.Response.RequestId,
+			InvokeLatencyMs: resp.LatencyMs,
+			APIType:         bedrock.APITypeConverse,
+		},
+		APIType: bedrock.APITypeConverse,
+	}
+	if resp.TokenUsage != nil {
+		bResp.TokenUsage = bedrock.TokenUsage{
+			InputTokens:    resp.TokenUsage.InputTokens,
+			OutputTokens:   resp.TokenUsage.OutputTokens,
+			ThinkingTokens: resp.TokenUsage.ThinkingTokens,
+			TotalTokens:    resp.TokenUsage.TotalTokens,
+		}
+	}
 
-        return &resp, nil
+	if err := bedrock.ValidateTurn1Response(&bResp); err != nil {
+		m.logger.Error("turn1_schema_validation_failed", map[string]interface{}{
+			"error":  err.Error(),
+			"bucket": ref.Bucket,
+			"key":    ref.Key,
+		})
+		return nil, &errors.WorkflowError{
+			Type:      errors.ErrorTypeValidation,
+			Code:      "InvalidTurn1Response",
+			Message:   err.Error(),
+			Retryable: false,
+			Severity:  errors.ErrorSeverityCritical,
+			APISource: errors.APISourceUnknown,
+			Timestamp: time.Now(),
+		}
+	}
+
+	return &resp, nil
 }
 
 // StoreTurn2Response stores the Turn2 response


### PR DESCRIPTION
## Summary
- convert `schema.TurnResponse` to `bedrock.Turn1Response` before validation
- ensure bedrock schema validation works with loaded Turn1 response

## Testing
- `GOWORK=off go build ./...` in `ExecuteTurn2Combined`

------
https://chatgpt.com/codex/tasks/task_b_684004e893d4832daafdae1845ea6210