### PR TITLE
Fix Turn1 metadata parsing

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
 
+## [2.2.20] - 2025-06-07
+### Fixed
+- `LoadTurn1SchemaResponse` now parses `bedrockMetadata` fields from
+  `turn1-raw-response.json`, ensuring `modelId` and `requestId` are
+  captured for schema validation.
 ## [2.2.19] - 2025-06-06
 ### Fixed
 - Added validation of Turn1 raw response when loading conversation history

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/s3_turn2.go
@@ -217,10 +217,15 @@ func (m *s3Manager) LoadTurn1SchemaResponse(ctx context.Context, ref models.S3Re
 			Response  struct {
 				Content []map[string]interface{} `json:"content"`
 			} `json:"response"`
-			LatencyMs  int64                  `json:"latencyMs"`
-			TokenUsage *schema.TokenUsage     `json:"tokenUsage,omitempty"`
-			Stage      string                 `json:"analysisStage"`
-			Metadata   map[string]interface{} `json:"metadata,omitempty"`
+			LatencyMs       int64                  `json:"latencyMs"`
+			TokenUsage      *schema.TokenUsage     `json:"tokenUsage,omitempty"`
+			Stage           string                 `json:"analysisStage"`
+			Metadata        map[string]interface{} `json:"metadata,omitempty"`
+			BedrockMetadata struct {
+				ModelId    string `json:"modelId"`
+				RequestId  string `json:"requestId"`
+				StopReason string `json:"stopReason,omitempty"`
+			} `json:"bedrockMetadata,omitempty"`
 		}
 
 		if altErr := json.Unmarshal(raw, &alt); altErr == nil {
@@ -232,6 +237,9 @@ func (m *s3Manager) LoadTurn1SchemaResponse(ctx context.Context, ref models.S3Re
 			resp.TokenUsage = alt.TokenUsage
 			resp.Stage = alt.Stage
 			resp.Metadata = alt.Metadata
+			resp.Response.ModelId = alt.BedrockMetadata.ModelId
+			resp.Response.RequestId = alt.BedrockMetadata.RequestId
+			resp.Response.StopReason = alt.BedrockMetadata.StopReason
 			for _, c := range alt.Response.Content {
 				if typ, ok := c["type"].(string); ok {
 					switch typ {


### PR DESCRIPTION
## Summary
- load bedrockMetadata when reading turn1 raw response
- document fix for missing modelId in CHANGELOG

## Testing
- `go test ./...` *(fails: module paths missing)*

------
https://chatgpt.com/codex/tasks/task_b_684009609d44832dabc2a6580573f5e6