### PR TITLE
Fix Turn2 prompt data sources and string matching

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter_turn2.go
@@ -2,6 +2,7 @@ package bedrock
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"workflow-function/ExecuteTurn2Combined/internal/config"
@@ -452,20 +453,8 @@ func (a *AdapterTurn2) truncateForLog(s string, maxLen int) string {
 
 // contains checks if a string contains a substring (case-insensitive)
 func contains(s, substr string) bool {
-	return len(s) >= len(substr) &&
-		(s == substr ||
-			len(s) > len(substr) &&
-				(s[:len(substr)] == substr ||
-					s[len(s)-len(substr):] == substr ||
-					indexContains(s, substr) >= 0))
-}
-
-// indexContains finds substring in string
-func indexContains(s, substr string) int {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return i
-		}
+	if substr == "" {
+		return false
 	}
-	return -1
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
 }

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/prompt_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/prompt_turn2.go
@@ -98,11 +98,11 @@ func (p *promptServiceTurn2) GenerateTurn2PromptWithMetrics(ctx context.Context,
 		},
 		"imageReference": map[string]interface{}{
 			"base64StorageReference": map[string]string{
-				"bucket": "kootoro-dev-s3-state-f6d3xl",
-				"key":    "checking-base64.base64",
+				"bucket": p.cfg.AWS.S3Bucket,
+				"key":    vCtx.CheckingImageUrl,
 			},
 			"imageType": "checking",
-			"sourceUrl": "s3://kootoro-dev-s3-state-f6d3xl/checking-base64.base64",
+			"sourceUrl": fmt.Sprintf("s3://%s/%s", p.cfg.AWS.S3Bucket, vCtx.CheckingImageUrl),
 		},
 		"messageStructure": map[string]interface{}{
 			"content": []map[string]string{


### PR DESCRIPTION
## Summary
- turn structured Turn2 prompts use configured bucket and S3 key from context instead of hard-coded values
- simplify `contains` helper and make search case-insensitive

## Testing
- `go vet ./...` *(fails: cannot load modules)*

------
https://chatgpt.com/codex/tasks/task_b_68400988ae44832d943d42d8b9b9b6ed