### PR TITLE
Fix thinking type default

### DIFF
--- a/product-approach/iac/locals.tf
+++ b/product-approach/iac/locals.tf
@@ -235,7 +235,7 @@ locals {
         BEDROCK_MODEL               = var.bedrock.model_id
         MAX_TOKENS                  = var.bedrock.max_tokens
         BUDGET_TOKENS               = var.bedrock.budget_tokens
-        THINKING_TYPE               = "enable"
+        THINKING_TYPE               = "enabled"
         DYNAMODB_CONVERSATION_TABLE = local.dynamodb_tables.conversation_history
         LOG_LEVEL                   = "INFO"
         REFERENCE_BUCKET            = local.s3_buckets.reference

--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.2.21] - 2025-06-08
+### Fixed
+- Default `THINKING_TYPE` environment variable now set to `enabled` to ensure
+  temperature validation passes when `TEMPERATURE=1`.
+
+
 
 ## [2.2.20] - 2025-06-07
 ### Fixed

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
@@ -72,7 +72,7 @@ func LoadConfiguration() (*Config, error) {
 
 	cfg.Processing.MaxTokens = getInt("MAX_TOKENS", 24000)
 	cfg.Processing.BudgetTokens = getInt("BUDGET_TOKENS", 16000)
-	cfg.Processing.ThinkingType = getEnv("THINKING_TYPE", "enable")
+	cfg.Processing.ThinkingType = getEnv("THINKING_TYPE", "enabled")
 	cfg.Processing.Temperature = getFloat("TEMPERATURE", 0.7)
 	cfg.Processing.MaxRetries = getInt("MAX_RETRIES", 1)
 	cfg.Processing.BedrockConnectTimeoutSec = getInt("BEDROCK_CONNECT_TIMEOUT_SEC", 10)

--- a/product-approach/workflow-function/shared/bedrock/THINKING_BLOCKS_FIX.md
+++ b/product-approach/workflow-function/shared/bedrock/THINKING_BLOCKS_FIX.md
@@ -142,7 +142,7 @@ The fix uses a **defensive programming approach**:
 
 To test the implementation:
 
-1. **Set Environment Variable**: `THINKING_TYPE=enable`
+1. **Set Environment Variable**: `THINKING_TYPE=enabled`
 2. **Deploy Lambda**: Deploy ExecuteTurn1Combined with the updated shared client
 3. **Trigger Verification**: Run a vending machine verification
 4. **Check Logs**: Look for thinking-related log messages in CloudWatch
@@ -150,7 +150,7 @@ To test the implementation:
 
 ## Expected Behavior
 
-With `THINKING_TYPE=enable`:
+With `THINKING_TYPE=enabled`:
 - ✅ Reasoning configuration is sent to Bedrock API
 - ✅ Content blocks are analyzed for thinking content
 - ✅ Token usage is checked for thinking tokens


### PR DESCRIPTION
## Summary
- fix THINKING_TYPE default
- update docs for new environment variable value
- set THINKING_TYPE to enabled for prepare_system_prompt Lambda

## Testing
- `go test ./...` *(fails: cannot load modules)*

------
https://chatgpt.com/codex/tasks/task_b_68401120938c832d82898b861b6e55fc