### PR TITLE
Fix thinking config default

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"workflow-function/shared/errors"
@@ -72,7 +71,7 @@ func LoadConfiguration() (*Config, error) {
 
 	cfg.Processing.MaxTokens = getInt("MAX_TOKENS", 24000)
 	cfg.Processing.BudgetTokens = getInt("BUDGET_TOKENS", 16000)
-	cfg.Processing.ThinkingType = getEnv("THINKING_TYPE", "enabled")
+	cfg.Processing.ThinkingType = getEnv("THINKING_TYPE", "disabled")
 	cfg.Processing.Temperature = getFloat("TEMPERATURE", 0.7)
 	cfg.Processing.MaxRetries = getInt("MAX_RETRIES", 1)
 	cfg.Processing.BedrockConnectTimeoutSec = getInt("BEDROCK_CONNECT_TIMEOUT_SEC", 10)
@@ -149,5 +148,5 @@ func (c *Config) DatePartitionFromTimestamp(ts string) (string, error) {
 // Thinking is enabled only when THINKING_TYPE is explicitly set to "enabled"
 // Thinking is disabled when THINKING_TYPE is "disable" or unset (empty string)
 func (c *Config) IsThinkingEnabled() bool {
-	return strings.EqualFold(c.Processing.ThinkingType, "enabled")
+	return c.Processing.ThinkingType == "enabled"
 }


### PR DESCRIPTION
## Summary
- align `THINKING_TYPE` default with ExecuteTurn1Combined
- simplify `IsThinkingEnabled` and drop unused `strings` import

## Testing
- `GOWORK=off go vet ./...`
- `GOWORK=off go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_68401ee65d74832da1439c4ececd7ac8