### PR TITLE
Remove obsolete thinking config

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/cmd/main.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/cmd/main.go
@@ -241,8 +241,8 @@ func initializeServiceLayerWithLocalBedrock(awsConfig aws.Config, cfg *internalC
 		cfg.AWS.Region,
 		cfg.AWS.AnthropicVersion,
 		cfg.Processing.MaxTokens,
-		cfg.Processing.ThinkingType,
-		cfg.Processing.BudgetTokens,
+		"",
+		0,
 	)
 
 	sharedClient, err := sharedBedrock.NewBedrockClient(

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/config/config.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/config/config.go
@@ -21,8 +21,6 @@ type Config struct {
 	}
 	Processing struct {
 		MaxTokens                int
-		BudgetTokens             int
-		ThinkingType             string
 		Temperature              float64
 		MaxRetries               int
 		BedrockConnectTimeoutSec int
@@ -68,8 +66,6 @@ func LoadConfiguration() (*Config, error) {
 	}
 
 	cfg.Processing.MaxTokens = getInt("MAX_TOKENS", 24000)
-	cfg.Processing.BudgetTokens = getInt("BUDGET_TOKENS", 16000)
-	cfg.Processing.ThinkingType = getEnv("THINKING_TYPE", "disabled")
 	cfg.Processing.Temperature = getFloat("TEMPERATURE", 0.7)
 	cfg.Processing.MaxRetries = getInt("MAX_RETRIES", 1)
 	cfg.Processing.BedrockConnectTimeoutSec = getInt("BEDROCK_CONNECT_TIMEOUT_SEC", 10)
@@ -138,11 +134,4 @@ func (c *Config) DatePartitionFromTimestamp(ts string) (string, error) {
 	}
 	t = t.In(loc)
 	return fmt.Sprintf("%04d/%02d/%02d", t.Year(), t.Month(), t.Day()), nil
-}
-
-// IsThinkingEnabled returns true if thinking/reasoning mode is enabled
-// Thinking is enabled only when THINKING_TYPE is explicitly set to "enabled"
-// Thinking is disabled when THINKING_TYPE is "disable" or unset (empty string)
-func (c *Config) IsThinkingEnabled() bool {
-	return c.Processing.ThinkingType == "enabled"
 }

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/config/validate.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/config/validate.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"strings"
 	"time"
 	"workflow-function/shared/errors"
 )
@@ -46,15 +45,6 @@ func (c *Config) Validate() error {
 	if c.Processing.Temperature < 0 || c.Processing.Temperature > 1 {
 		return errors.NewValidationError("temperature must be between 0 and 1",
 			map[string]interface{}{"current_value": c.Processing.Temperature})
-	}
-
-	// Validate temperature and thinking compatibility
-	if c.Processing.Temperature == 1 && !strings.EqualFold(c.Processing.ThinkingType, "enabled") {
-		return errors.NewValidationError("temperature may only be set to 1 when thinking is enabled",
-			map[string]interface{}{
-				"current_value": c.Processing.Temperature,
-				"thinking_type": c.Processing.ThinkingType,
-			})
 	}
 
 	return nil

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/storage_manager.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/storage_manager.go
@@ -192,11 +192,10 @@ func (s *StorageManager) StoreResponses(ctx context.Context, req *models.Turn1Re
 
 	// Build enhanced bedrock metadata with thinking support
 	bedrockMetadata := map[string]interface{}{
-		"modelId":         s.cfg.AWS.BedrockModel,
-		"requestId":       resp.RequestID,
-		"stopReason":      stopReason,
-		"hasThinking":     hasThinking,
-		"thinkingEnabled": s.cfg.Processing.ThinkingType == "enable",
+		"modelId":     s.cfg.AWS.BedrockModel,
+		"requestId":   resp.RequestID,
+		"stopReason":  stopReason,
+		"hasThinking": hasThinking,
 	}
 
 	// Add thinking-specific metadata if available

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/bedrock.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/services/bedrock.go
@@ -29,27 +29,13 @@ func NewBedrockService(ctx context.Context, cfg config.Config) (BedrockService, 
 	// Initialize structured logger for comprehensive observability
 	log := logger.New("ExecuteTurn1Combined", "BedrockService")
 
-	// Create shared bedrock client first
-	// Use the thinking type directly from configuration instead of hardcoding
-	thinkingType := cfg.Processing.ThinkingType
-	if cfg.IsThinkingEnabled() {
-		log.Info("THINKING_SERVICE_ENABLED", map[string]interface{}{
-			"thinking_type":   thinkingType,
-			"budget_tokens":   cfg.Processing.BudgetTokens,
-			"env_thinking_type": cfg.Processing.ThinkingType,
-		})
-	} else {
-		log.Info("THINKING_SERVICE_DISABLED", map[string]interface{}{
-			"thinking_type":   thinkingType,
-			"env_thinking_type": cfg.Processing.ThinkingType,
-		})
-	}
+	// Create shared bedrock client
 	clientConfig := sharedBedrock.CreateClientConfig(
 		cfg.AWS.Region,
 		cfg.AWS.AnthropicVersion,
 		cfg.Processing.MaxTokens,
-		thinkingType,
-		cfg.Processing.BudgetTokens,
+		"",
+		0,
 	)
 
 	sharedClient, err := sharedBedrock.NewBedrockClient(ctx, cfg.AWS.BedrockModel, clientConfig)
@@ -66,8 +52,8 @@ func NewBedrockService(ctx context.Context, cfg config.Config) (BedrockService, 
 		AnthropicVersion: cfg.AWS.AnthropicVersion,
 		MaxTokens:        cfg.Processing.MaxTokens,
 		Temperature:      cfg.Processing.Temperature,
-		ThinkingType:     cfg.Processing.ThinkingType,
-		ThinkingBudget:   cfg.Processing.BudgetTokens,
+		ThinkingType:     "",
+		ThinkingBudget:   0,
 		Timeout:          time.Duration(cfg.Processing.BedrockCallTimeoutSec) * time.Second,
 		Region:           cfg.AWS.Region,
 	}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter.go
@@ -99,35 +99,11 @@ func (a *Adapter) buildConverseRequest(systemPrompt, turnPrompt, base64Image str
 		nil, // TopP - defer to model defaults
 	)
 
-	// Add thinking/reasoning configuration if enabled
-	if config.ThinkingType == "enable" {
-		request.Reasoning = "enable"
-		request.InferenceConfig.Reasoning = "enable"
-		request.Thinking = map[string]interface{}{
-			"type":          "enabled",
-			"budget_tokens": config.ThinkingBudget,
-		}
-		a.logger.Info("THINKING_ADAPTER_ENABLED", map[string]interface{}{
-			"thinking_type":         config.ThinkingType,
-			"budget_tokens":         config.ThinkingBudget,
-			"request_reasoning":     request.Reasoning,
-			"inference_reasoning":   request.InferenceConfig.Reasoning,
-			"request_thinking":      request.Thinking,
-		})
-	} else {
-		a.logger.Info("THINKING_ADAPTER_DISABLED", map[string]interface{}{
-			"thinking_type":       config.ThinkingType,
-			"request_reasoning":   request.Reasoning,
-			"inference_reasoning": request.InferenceConfig.Reasoning,
-		})
-	}
-
 	// Log the complete request structure for debugging
-	a.logger.Info("THINKING_REQUEST_STRUCTURE", map[string]interface{}{
+	a.logger.Info("bedrock_request_structure", map[string]interface{}{
 		"model_id":            request.ModelId,
 		"reasoning_field":     request.Reasoning,
 		"inference_reasoning": request.InferenceConfig.Reasoning,
-		"thinking_field":      request.Thinking,
 		"max_tokens":          request.InferenceConfig.MaxTokens,
 	})
 
@@ -203,4 +179,3 @@ func (a *Adapter) detectImageFormat(base64Data string) string {
 	// Default to PNG for maximum compatibility
 	return "png"
 }
-

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client.go
@@ -2,7 +2,6 @@ package bedrock
 
 import (
 	"context"
-	"strings"
 
 	"workflow-function/shared/bedrock"
 	"workflow-function/shared/errors"
@@ -67,14 +66,6 @@ func (c *Client) ValidateConfiguration() error {
 	if c.config.Temperature < 0 || c.config.Temperature > 1 {
 		return errors.NewValidationError("temperature must be between 0 and 1",
 			map[string]interface{}{"current_value": c.config.Temperature})
-	}
-
-	if c.config.Temperature == 1 && !strings.EqualFold(c.config.ThinkingType, "enable") && !strings.EqualFold(c.config.ThinkingType, "enabled") {
-		return errors.NewValidationError("temperature may only be set to 1 when thinking is enabled",
-			map[string]interface{}{
-				"current_value": c.config.Temperature,
-				"thinking_type": c.config.ThinkingType,
-			})
 	}
 
 	return nil

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client_turn2.go
@@ -24,8 +24,8 @@ func NewClientTurn2(cfg config.Config, log logger.Logger) (*ClientTurn2, error) 
 		cfg.AWS.Region,
 		cfg.AWS.AnthropicVersion,
 		cfg.Processing.MaxTokens,
-		cfg.Processing.ThinkingType,
-		cfg.Processing.BudgetTokens,
+		"",
+		0,
 	)
 
 	sharedClient, err := sharedBedrock.NewBedrockClient(
@@ -46,8 +46,8 @@ func NewClientTurn2(cfg config.Config, log logger.Logger) (*ClientTurn2, error) 
 		AnthropicVersion: cfg.AWS.AnthropicVersion,
 		MaxTokens:        cfg.Processing.MaxTokens,
 		Temperature:      cfg.Processing.Temperature,
-		ThinkingType:     cfg.Processing.ThinkingType,
-		ThinkingBudget:   cfg.Processing.BudgetTokens,
+		ThinkingType:     "",
+		ThinkingBudget:   0,
 		Timeout:          time.Duration(cfg.Processing.BedrockCallTimeoutSec) * time.Second,
 		Region:           cfg.AWS.Region,
 	}

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"workflow-function/shared/errors"
@@ -22,8 +21,6 @@ type Config struct {
 	}
 	Processing struct {
 		MaxTokens                int
-		BudgetTokens             int
-		ThinkingType             string
 		Temperature              float64
 		MaxRetries               int
 		BedrockConnectTimeoutSec int
@@ -71,8 +68,6 @@ func LoadConfiguration() (*Config, error) {
 	}
 
 	cfg.Processing.MaxTokens = getInt("MAX_TOKENS", 24000)
-	cfg.Processing.BudgetTokens = getInt("BUDGET_TOKENS", 16000)
-	cfg.Processing.ThinkingType = getEnv("THINKING_TYPE", "enabled")
 	cfg.Processing.Temperature = getFloat("TEMPERATURE", 0.7)
 	cfg.Processing.MaxRetries = getInt("MAX_RETRIES", 1)
 	cfg.Processing.BedrockConnectTimeoutSec = getInt("BEDROCK_CONNECT_TIMEOUT_SEC", 10)
@@ -143,11 +138,4 @@ func (c *Config) DatePartitionFromTimestamp(ts string) (string, error) {
 	}
 	t = t.In(loc)
 	return fmt.Sprintf("%04d/%02d/%02d", t.Year(), t.Month(), t.Day()), nil
-}
-
-// IsThinkingEnabled returns true if thinking/reasoning mode is enabled
-// Thinking is enabled only when THINKING_TYPE is explicitly set to "enabled"
-// Thinking is disabled when THINKING_TYPE is "disable" or unset (empty string)
-func (c *Config) IsThinkingEnabled() bool {
-	return strings.EqualFold(c.Processing.ThinkingType, "enabled")
 }

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/validate.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/validate.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"strings"
 	"time"
 	"workflow-function/shared/errors"
 )
@@ -46,15 +45,6 @@ func (c *Config) Validate() error {
 	if c.Processing.Temperature < 0 || c.Processing.Temperature > 1 {
 		return errors.NewValidationError("temperature must be between 0 and 1",
 			map[string]interface{}{"current_value": c.Processing.Temperature})
-	}
-
-	// Validate temperature and thinking compatibility
-	if c.Processing.Temperature == 1 && !strings.EqualFold(c.Processing.ThinkingType, "enabled") {
-		return errors.NewValidationError("temperature may only be set to 1 when thinking is enabled",
-			map[string]interface{}{
-				"current_value": c.Processing.Temperature,
-				"thinking_type": c.Processing.ThinkingType,
-			})
 	}
 
 	return nil

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/bedrock.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/bedrock.go
@@ -34,8 +34,8 @@ func NewBedrockService(ctx context.Context, cfg config.Config) (BedrockService, 
 		cfg.AWS.Region,
 		cfg.AWS.AnthropicVersion,
 		cfg.Processing.MaxTokens,
-		cfg.Processing.ThinkingType,
-		cfg.Processing.BudgetTokens,
+		"",
+		0,
 	)
 
 	sharedClient, err := sharedBedrock.NewBedrockClient(ctx, cfg.AWS.BedrockModel, clientConfig)
@@ -52,8 +52,8 @@ func NewBedrockService(ctx context.Context, cfg config.Config) (BedrockService, 
 		AnthropicVersion: cfg.AWS.AnthropicVersion,
 		MaxTokens:        cfg.Processing.MaxTokens,
 		Temperature:      cfg.Processing.Temperature,
-		ThinkingType:     cfg.Processing.ThinkingType,
-		ThinkingBudget:   cfg.Processing.BudgetTokens,
+		ThinkingType:     "",
+		ThinkingBudget:   0,
 		Timeout:          time.Duration(cfg.Processing.BedrockCallTimeoutSec) * time.Second,
 		Region:           cfg.AWS.Region,
 	}


### PR DESCRIPTION
## Summary
- drop BudgetTokens and ThinkingType from processing configs
- strip thinking-specific logic from services and adapters
- update handlers after removing thinking fields

## Testing
- `GOWORK=off go build ./...` in `ExecuteTurn1Combined`
- `GOWORK=off go build ./...` in `ExecuteTurn2Combined`


------
https://chatgpt.com/codex/tasks/task_b_68401e6e4214832d87f6417fdf10afda