### PR TITLE
Remove thinking fields from bedrock types

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter_turn2.go
@@ -274,28 +274,24 @@ func (a *AdapterTurn2) ConverseWithHistory(ctx context.Context, systemPrompt, tu
 		"operation":  "bedrock_converse_with_history",
 	})
 
-	// Extract text and thinking content from response
+	// Extract text content from response
 	textContent := sharedBedrock.ExtractTextFromResponse(response)
-	thinkingText := sharedBedrock.ExtractThinkingFromResponse(response)
 
 	// Map token usage defensively
 	tokenUsage := schema.TokenUsage{
-		InputTokens:    0,
-		OutputTokens:   0,
-		ThinkingTokens: 0,
-		TotalTokens:    0,
+		InputTokens:  0,
+		OutputTokens: 0,
+		TotalTokens:  0,
 	}
 	if response.Usage != nil {
 		tokenUsage.InputTokens = response.Usage.InputTokens
 		tokenUsage.OutputTokens = response.Usage.OutputTokens
-		tokenUsage.ThinkingTokens = response.Usage.ThinkingTokens
 		tokenUsage.TotalTokens = response.Usage.TotalTokens
 	}
 
 	// Translate to schema.BedrockResponse
 	schemaResponse := &schema.BedrockResponse{
 		Content:          textContent,
-		Thinking:         thinkingText,
 		CompletionReason: response.StopReason,
 		InputTokens:      tokenUsage.InputTokens,
 		OutputTokens:     tokenUsage.OutputTokens,
@@ -308,28 +304,12 @@ func (a *AdapterTurn2) ConverseWithHistory(ctx context.Context, systemPrompt, tu
 		Metadata:         map[string]interface{}{},
 	}
 
-	// Populate thinking metadata
-	if thinkingText != "" {
-		blocks := a.generateThinkingBlocks(thinkingText, "response-processing")
-		schemaResponse.Metadata["thinking_blocks"] = blocks
-		schemaResponse.Metadata["has_thinking"] = true
-		schemaResponse.Metadata["thinking_length"] = len(thinkingText)
-		a.log.Info("thinking_extracted", map[string]interface{}{
-			"thinking_tokens": tokenUsage.ThinkingTokens,
-			"blocks":          len(blocks),
-		})
-	} else {
-		schemaResponse.Metadata["has_thinking"] = false
-		a.log.Info("thinking_not_found", nil)
-	}
-
 	// Log response details
 	a.log.Info("bedrock_turn2_response_received", map[string]interface{}{
 		"model_id":           response.ModelID,
 		"completion_reason":  response.StopReason,
 		"input_tokens":       tokenUsage.InputTokens,
 		"output_tokens":      tokenUsage.OutputTokens,
-		"thinking_tokens":    tokenUsage.ThinkingTokens,
 		"latency_ms":         latencyMs,
 		"content_length":     len(textContent),
 		"processing_time_ms": schemaResponse.ProcessingTimeMs,
@@ -359,96 +339,4 @@ func (a *AdapterTurn2) ProcessTurn2(ctx context.Context, systemPrompt, turn2Prom
 	}
 
 	return response, nil
-}
-
-// ThinkingBlock represents a structured thinking analysis block
-type ThinkingBlock struct {
-	Timestamp  string `json:"timestamp"`
-	Component  string `json:"component"`
-	Stage      string `json:"stage"`
-	Decision   string `json:"decision"`
-	Reasoning  string `json:"reasoning"`
-	Confidence int    `json:"confidence"`
-}
-
-// generateThinkingBlocks creates structured thinking blocks for analysis
-func (a *AdapterTurn2) generateThinkingBlocks(thinking string, stage string) []ThinkingBlock {
-	if thinking == "" {
-		return []ThinkingBlock{}
-	}
-
-	blocks := []ThinkingBlock{
-		{
-			Timestamp:  schema.FormatISO8601(),
-			Component:  "bedrock-adapter",
-			Stage:      stage,
-			Decision:   "Extracted thinking content from response",
-			Reasoning:  a.summarizeThinking(thinking),
-			Confidence: a.calculateThinkingConfidence(thinking),
-		},
-	}
-
-	if len(thinking) > 500 {
-		blocks = append(blocks, ThinkingBlock{
-			Timestamp:  schema.FormatISO8601(),
-			Component:  "bedrock-adapter",
-			Stage:      "content-analysis",
-			Decision:   "Analyzed comprehensive thinking content",
-			Reasoning:  "Thinking content exceeds 500 characters, indicating detailed reasoning process",
-			Confidence: 90,
-		})
-	}
-
-	return blocks
-}
-
-// summarizeThinking creates a summary of thinking content for reasoning field
-func (a *AdapterTurn2) summarizeThinking(thinking string) string {
-	if len(thinking) <= 200 {
-		return thinking
-	}
-
-	summary := thinking[:150] + "... [Content extracted using multi-strategy approach: reasoning tags, thinking tags, markdown blocks, and section headers]"
-	return summary
-}
-
-// calculateThinkingConfidence estimates confidence based on thinking content characteristics
-func (a *AdapterTurn2) calculateThinkingConfidence(thinking string) int {
-	confidence := 70
-
-	if len(thinking) > 100 {
-		confidence += 10
-	}
-	if len(thinking) > 500 {
-		confidence += 10
-	}
-
-	indicators := []string{"analysis", "reasoning", "conclusion", "evidence", "assessment"}
-	for _, ind := range indicators {
-		if contains(thinking, ind) {
-			confidence += 2
-		}
-	}
-
-	if confidence > 95 {
-		confidence = 95
-	}
-
-	return confidence
-}
-
-// truncateForLog safely truncates strings for logging
-func (a *AdapterTurn2) truncateForLog(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
-}
-
-// contains checks if a string contains a substring (case-insensitive)
-func contains(s, substr string) bool {
-	if substr == "" {
-		return false
-	}
-	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
 }

--- a/product-approach/workflow-function/shared/bedrock/response.go
+++ b/product-approach/workflow-function/shared/bedrock/response.go
@@ -27,22 +27,17 @@ func (rp *ResponseProcessor) ProcessTurn1Response(
 		return nil, fmt.Errorf("no text content in response")
 	}
 
-	// Extract thinking content from response
-	thinkingText := ExtractThinkingFromResponse(response)
-
 	// Create token usage
 	tokenUsage := TokenUsage{
-		InputTokens:    0,
-		OutputTokens:   0,
-		ThinkingTokens: 0,
-		TotalTokens:    0,
+		InputTokens:  0,
+		OutputTokens: 0,
+		TotalTokens:  0,
 	}
 
 	// Copy token usage if available
 	if response.Usage != nil {
 		tokenUsage.InputTokens = response.Usage.InputTokens
 		tokenUsage.OutputTokens = response.Usage.OutputTokens
-		tokenUsage.ThinkingTokens = response.Usage.ThinkingTokens
 		tokenUsage.TotalTokens = response.Usage.TotalTokens
 	}
 
@@ -55,7 +50,6 @@ func (rp *ResponseProcessor) ProcessTurn1Response(
 			Content:    responseText,
 			StopReason: response.StopReason,
 		},
-		Thinking:      thinkingText,
 		LatencyMs:     latencyMs,
 		TokenUsage:    tokenUsage,
 		AnalysisStage: AnalysisStageTurn1,
@@ -84,22 +78,17 @@ func (rp *ResponseProcessor) ProcessTurn2Response(
 		return nil, fmt.Errorf("no text content in response")
 	}
 
-	// Extract thinking content from response
-	thinkingText := ExtractThinkingFromResponse(response)
-
 	// Create token usage
 	tokenUsage := TokenUsage{
-		InputTokens:    0,
-		OutputTokens:   0,
-		ThinkingTokens: 0,
-		TotalTokens:    0,
+		InputTokens:  0,
+		OutputTokens: 0,
+		TotalTokens:  0,
 	}
 
 	// Copy token usage if available
 	if response.Usage != nil {
 		tokenUsage.InputTokens = response.Usage.InputTokens
 		tokenUsage.OutputTokens = response.Usage.OutputTokens
-		tokenUsage.ThinkingTokens = response.Usage.ThinkingTokens
 		tokenUsage.TotalTokens = response.Usage.TotalTokens
 	}
 
@@ -112,7 +101,6 @@ func (rp *ResponseProcessor) ProcessTurn2Response(
 			Content:    responseText,
 			StopReason: response.StopReason,
 		},
-		Thinking:      thinkingText,
 		LatencyMs:     latencyMs,
 		TokenUsage:    tokenUsage,
 		AnalysisStage: AnalysisStageTurn2,

--- a/product-approach/workflow-function/shared/bedrock/types.go
+++ b/product-approach/workflow-function/shared/bedrock/types.go
@@ -23,13 +23,12 @@ const (
 
 // ConverseRequest represents a request to the Bedrock Converse API
 type ConverseRequest struct {
-	ModelId         string                `json:"modelId"`
-	Messages        []MessageWrapper      `json:"messages"`
-	System          string                `json:"system,omitempty"`
-	InferenceConfig InferenceConfig       `json:"inferenceConfig,omitempty"`
-	GuardrailConfig *GuardrailConfig      `json:"guardrailConfig,omitempty"`
-	Reasoning       string                `json:"reasoning,omitempty"` // Added for Claude 3.5 Sonnet thinking support
-	Thinking        map[string]interface{} `json:"thinking,omitempty"`   // Added for AWS Bedrock extended thinking API
+	ModelId         string           `json:"modelId"`
+	Messages        []MessageWrapper `json:"messages"`
+	System          string           `json:"system,omitempty"`
+	InferenceConfig InferenceConfig  `json:"inferenceConfig,omitempty"`
+	GuardrailConfig *GuardrailConfig `json:"guardrailConfig,omitempty"`
+	Reasoning       string           `json:"reasoning,omitempty"` // Added for Claude 3.5 Sonnet thinking support
 }
 
 // MessageWrapper represents a message in the Converse API
@@ -54,17 +53,17 @@ type ImageBlock struct {
 // ImageSource represents the source of an image
 // Only supports bytes (base64 encoded data)
 type ImageSource struct {
-	Type  string `json:"type"`        // Must be "bytes"
-	Bytes string `json:"bytes"`       // Base64 encoded image data
+	Type  string `json:"type"`  // Must be "bytes"
+	Bytes string `json:"bytes"` // Base64 encoded image data
 }
 
 // InferenceConfig represents configuration for the Bedrock Converse API
 type InferenceConfig struct {
-	MaxTokens     int       `json:"maxTokens"`
-	Temperature   *float64  `json:"temperature,omitempty"`
-	TopP          *float64  `json:"topP,omitempty"`
-	StopSequences []string  `json:"stopSequences,omitempty"`
-	Reasoning     string    `json:"reasoning,omitempty"` // Added for Claude 3.5 Sonnet thinking support
+	MaxTokens     int      `json:"maxTokens"`
+	Temperature   *float64 `json:"temperature,omitempty"`
+	TopP          *float64 `json:"topP,omitempty"`
+	StopSequences []string `json:"stopSequences,omitempty"`
+	Reasoning     string   `json:"reasoning,omitempty"` // Added for Claude 3.5 Sonnet thinking support
 }
 
 // GuardrailConfig represents configuration for guardrails in Bedrock
@@ -75,20 +74,19 @@ type GuardrailConfig struct {
 
 // ConverseResponse represents a response from the Bedrock Converse API
 type ConverseResponse struct {
-	RequestID  string         `json:"requestId"`
-	ModelID    string         `json:"modelId"`
-	StopReason string         `json:"stopReason,omitempty"`
-	Content    []ContentBlock `json:"content"`
-	Usage      *TokenUsage    `json:"usage,omitempty"`
+	RequestID  string           `json:"requestId"`
+	ModelID    string           `json:"modelId"`
+	StopReason string           `json:"stopReason,omitempty"`
+	Content    []ContentBlock   `json:"content"`
+	Usage      *TokenUsage      `json:"usage,omitempty"`
 	Metrics    *ResponseMetrics `json:"metrics,omitempty"`
 }
 
 // TokenUsage represents token usage metrics from Bedrock
 type TokenUsage struct {
-	InputTokens    int `json:"inputTokens"`
-	OutputTokens   int `json:"outputTokens"`
-	ThinkingTokens int `json:"thinkingTokens,omitempty"` // Added for Claude reasoning support
-	TotalTokens    int `json:"totalTokens"`
+	InputTokens  int `json:"inputTokens"`
+	OutputTokens int `json:"outputTokens"`
+	TotalTokens  int `json:"totalTokens"`
 }
 
 // ResponseMetrics represents metrics about the response from Bedrock
@@ -98,9 +96,8 @@ type ResponseMetrics struct {
 
 // TextResponse represents the text response portion of a model's output
 type TextResponse struct {
-	Content     string  `json:"content"`
-	StopReason  string  `json:"stop_reason,omitempty"`
-	Thinking    string  `json:"thinking,omitempty"`
+	Content    string `json:"content"`
+	StopReason string `json:"stop_reason,omitempty"`
 }
 
 // BedrockMetadata represents metadata about the Bedrock request
@@ -113,31 +110,29 @@ type BedrockMetadata struct {
 
 // Turn1Response represents the response from Turn 1 of a multi-turn conversation
 type Turn1Response struct {
-	TurnID          int              `json:"turnId"`
-	Timestamp       string           `json:"timestamp"`
-	Prompt          string           `json:"prompt"`
-	Response        TextResponse     `json:"response"`
-	Thinking        string           `json:"thinking,omitempty"`        // Thinking content if available
-	LatencyMs       int64            `json:"latencyMs"`
-	TokenUsage      TokenUsage       `json:"tokenUsage"`
-	AnalysisStage   string           `json:"analysisStage"`
-	BedrockMetadata BedrockMetadata  `json:"bedrockMetadata"`
-	APIType         string           `json:"apiType,omitempty"` // Always "Converse"
+	TurnID          int             `json:"turnId"`
+	Timestamp       string          `json:"timestamp"`
+	Prompt          string          `json:"prompt"`
+	Response        TextResponse    `json:"response"`
+	LatencyMs       int64           `json:"latencyMs"`
+	TokenUsage      TokenUsage      `json:"tokenUsage"`
+	AnalysisStage   string          `json:"analysisStage"`
+	BedrockMetadata BedrockMetadata `json:"bedrockMetadata"`
+	APIType         string          `json:"apiType,omitempty"` // Always "Converse"
 }
 
 // Turn2Response represents the response from Turn 2 of a multi-turn conversation
 type Turn2Response struct {
-	TurnID          int              `json:"turnId"`
-	Timestamp       string           `json:"timestamp"`
-	Prompt          string           `json:"prompt"`
-	Response        TextResponse     `json:"response"`
-	Thinking        string           `json:"thinking,omitempty"`        // Thinking content if available
-	LatencyMs       int64            `json:"latencyMs"`
-	TokenUsage      TokenUsage       `json:"tokenUsage"`
-	AnalysisStage   string           `json:"analysisStage"`
-	BedrockMetadata BedrockMetadata  `json:"bedrockMetadata"`
-	APIType         string           `json:"apiType,omitempty"` // Always "Converse"
-	PreviousTurn    *Turn1Response   `json:"previousTurn,omitempty"`
+	TurnID          int             `json:"turnId"`
+	Timestamp       string          `json:"timestamp"`
+	Prompt          string          `json:"prompt"`
+	Response        TextResponse    `json:"response"`
+	LatencyMs       int64           `json:"latencyMs"`
+	TokenUsage      TokenUsage      `json:"tokenUsage"`
+	AnalysisStage   string          `json:"analysisStage"`
+	BedrockMetadata BedrockMetadata `json:"bedrockMetadata"`
+	APIType         string          `json:"apiType,omitempty"` // Always "Converse"
+	PreviousTurn    *Turn1Response  `json:"previousTurn,omitempty"`
 }
 
 // VerificationResult represents the result of a verification operation
@@ -154,24 +149,24 @@ type VerificationResult struct {
 
 // VerificationStatus represents the status of a verification operation
 type VerificationStatus struct {
-	Status          string `json:"status"`          // PROCESSING, COMPLETED, FAILED
-	VerificationId  string `json:"verificationId"`
-	VerificationAt  string `json:"verificationAt"`
-	Message         string `json:"message,omitempty"`
-	ErrorCode       string `json:"errorCode,omitempty"`
-	ErrorMessage    string `json:"errorMessage,omitempty"`
-	CompletedAt     string `json:"completedAt,omitempty"`
-	ProcessingTimeMs int64 `json:"processingTimeMs,omitempty"`
+	Status           string `json:"status"` // PROCESSING, COMPLETED, FAILED
+	VerificationId   string `json:"verificationId"`
+	VerificationAt   string `json:"verificationAt"`
+	Message          string `json:"message,omitempty"`
+	ErrorCode        string `json:"errorCode,omitempty"`
+	ErrorMessage     string `json:"errorMessage,omitempty"`
+	CompletedAt      string `json:"completedAt,omitempty"`
+	ProcessingTimeMs int64  `json:"processingTimeMs,omitempty"`
 }
 
 // DiscrepancyItem represents a discrepancy between reference and checking images
 type DiscrepancyItem struct {
-	Position          string  `json:"position"`
-	ExpectedProduct   string  `json:"expected"`
-	FoundProduct      string  `json:"found"`
-	Issue             string  `json:"issue"`
-	Confidence        float64 `json:"confidence"`
-	Evidence          string  `json:"evidence,omitempty"`
+	Position           string  `json:"position"`
+	ExpectedProduct    string  `json:"expected"`
+	FoundProduct       string  `json:"found"`
+	Issue              string  `json:"issue"`
+	Confidence         float64 `json:"confidence"`
+	Evidence           string  `json:"evidence,omitempty"`
 	VerificationResult string  `json:"verificationResult"`
 }
 
@@ -186,22 +181,22 @@ type VerificationSummary struct {
 	EmptyPositionsCount   int     `json:"emptyPositionsCount"`
 	OverallAccuracy       float64 `json:"overallAccuracy"`
 	OverallConfidence     float64 `json:"overallConfidence"`
-	VerificationStatus    string  `json:"verificationStatus"` // CORRECT, INCORRECT
+	VerificationStatus    string  `json:"verificationStatus"`  // CORRECT, INCORRECT
 	VerificationOutcome   string  `json:"verificationOutcome"` // Human-readable summary
 }
 
 // ProcessedResults represents the processed verification results
 type ProcessedResults struct {
-	VerificationId      string               `json:"verificationId"`
-	VerificationAt      string               `json:"verificationAt"`
-	Status              string               `json:"status"`
-	ReferenceImageUrl   string               `json:"referenceImageUrl"`
-	CheckingImageUrl    string               `json:"checkingImageUrl"`
-	Discrepancies       []DiscrepancyItem    `json:"discrepancies"`
-	VerificationSummary VerificationSummary  `json:"verificationSummary"`
-	Turn1Response       *Turn1Response       `json:"turn1Response,omitempty"`
-	Turn2Response       *Turn2Response       `json:"turn2Response,omitempty"`
-	ProcessingTimeMs    int64                `json:"processingTimeMs"`
+	VerificationId      string              `json:"verificationId"`
+	VerificationAt      string              `json:"verificationAt"`
+	Status              string              `json:"status"`
+	ReferenceImageUrl   string              `json:"referenceImageUrl"`
+	CheckingImageUrl    string              `json:"checkingImageUrl"`
+	Discrepancies       []DiscrepancyItem   `json:"discrepancies"`
+	VerificationSummary VerificationSummary `json:"verificationSummary"`
+	Turn1Response       *Turn1Response      `json:"turn1Response,omitempty"`
+	Turn2Response       *Turn2Response      `json:"turn2Response,omitempty"`
+	ProcessingTimeMs    int64               `json:"processingTimeMs"`
 }
 
 // ExtractTextFromResponse extracts text content from a Converse response
@@ -218,110 +213,4 @@ func ExtractTextFromResponse(response *ConverseResponse) string {
 	}
 
 	return strings.Join(textParts, "")
-}
-
-// ExtractThinkingFromResponse extracts thinking content from a Converse response
-// Uses multiple extraction strategies ported from old/ExecuteTurn1
-func ExtractThinkingFromResponse(response *ConverseResponse) string {
-	if response == nil || len(response.Content) == 0 {
-		return ""
-	}
-
-	// First, check for thinking content blocks (AWS SDK format)
-	var thinkingParts []string
-	for _, content := range response.Content {
-		if content.Type == "thinking" {
-			thinkingParts = append(thinkingParts, content.Text)
-		}
-	}
-
-	if len(thinkingParts) > 0 {
-		return strings.Join(thinkingParts, "")
-	}
-
-	// If no thinking content blocks found, extract from text content
-	// This handles cases where thinking is embedded in text responses
-	var allText []string
-	for _, content := range response.Content {
-		if content.Type == "text" {
-			allText = append(allText, content.Text)
-		}
-	}
-
-	if len(allText) == 0 {
-		return ""
-	}
-
-	// Apply multiple extraction strategies to the combined text
-	combinedText := strings.Join(allText, "")
-	return extractThinkingFromText(combinedText)
-}
-
-// extractThinkingFromText applies multiple thinking extraction strategies
-// Ported from old/ExecuteTurn1 proven implementation
-func extractThinkingFromText(text string) string {
-	if text == "" {
-		return ""
-	}
-
-	// Strategy 1: Claude 3.7 Bedrock standard reasoning format
-	if reasoning := extractContentBetweenTags(text, "<reasoning>", "</reasoning>"); reasoning != "" {
-		return strings.TrimSpace(reasoning)
-	}
-
-	// Strategy 2: Traditional thinking format
-	if thinking := extractContentBetweenTags(text, "<thinking>", "</thinking>"); thinking != "" {
-		return strings.TrimSpace(thinking)
-	}
-
-	// Strategy 3: Markdown code block format
-	if thinking := extractContentBetweenTags(text, "```thinking", "```"); thinking != "" {
-		return strings.TrimSpace(thinking)
-	}
-
-	// Strategy 4: Section header formats
-	headerFormats := []string{
-		"# Thinking\n",
-		"## Thinking\n",
-		"Thinking:\n",
-	}
-
-	for _, header := range headerFormats {
-		startIdx := strings.Index(text, header)
-		if startIdx >= 0 {
-			contentStart := startIdx + len(header)
-			// Try to find the end (next section or end of text)
-			endIdx := strings.Index(text[contentStart:], "\n#")
-
-			var thinking string
-			if endIdx >= 0 {
-				thinking = strings.TrimSpace(text[contentStart : contentStart+endIdx])
-			} else {
-				thinking = strings.TrimSpace(text[contentStart:])
-			}
-
-			if thinking != "" {
-				return thinking
-			}
-		}
-	}
-
-	// No thinking content found
-	return ""
-}
-
-// extractContentBetweenTags extracts content between start and end tags
-func extractContentBetweenTags(text, startTag, endTag string) string {
-	startIdx := strings.Index(text, startTag)
-	if startIdx == -1 {
-		return ""
-	}
-
-	contentStart := startIdx + len(startTag)
-	endIdx := strings.Index(text[contentStart:], endTag)
-	if endIdx == -1 {
-		return ""
-	}
-
-	return text[contentStart : contentStart+endIdx]
 }


### PR DESCRIPTION
## Summary
- drop ThinkingTokens and Thinking fields from bedrock structures
- stop injecting reasoning config and thinking processing in bedrock client
- trim response helpers and adapters to match new types

## Testing
- `gofmt -w product-approach/workflow-function/shared/bedrock/types.go`
- `gofmt -w product-approach/workflow-function/shared/bedrock/client.go`
- `gofmt -w product-approach/workflow-function/shared/bedrock/response.go`
- `gofmt -w product-approach/workflow-function/ExecuteTurn1Combined/internal/bedrock/adapter.go`
- `gofmt -w product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter_turn2.go`

------
https://chatgpt.com/codex/tasks/task_b_6840222f4060832d99fc9ef4041a40a7