### PR TITLE
Update READMEs for prompt caching

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/README.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/README.md
@@ -40,6 +40,7 @@ This Lambda function combines multiple steps of the vending machine verification
   - Organized environment variables by functional area
   - Sensible defaults with comprehensive validation
   - Support for different storage modes and timeouts
+  - Prompt templates are cached in memory for faster load times (set `TEMPLATE_CACHE_ENABLED=false` to disable)
 
 ---
 
@@ -88,8 +89,6 @@ The function uses these environment variables with sensible defaults:
 | DYNAMODB_CONVERSATION_TABLE | DynamoDB table for conversation logs  | (required)                  |
 | **Processing Configuration** |                                      |                            |
 | MAX_TOKENS                  | Max tokens for response               | 24000                       |
-| BUDGET_TOKENS               | Max tokens for thinking               | 16000                       |
-| THINKING_TYPE               | Thinking extraction pattern           | enable                      |
 | MAX_RETRIES                 | Max retry attempts                    | 3                           |
 | BEDROCK_TIMEOUT_SECONDS     | Timeout for Bedrock calls             | 120                         |
 | **Logging Configuration**   |                                       |                            |
@@ -98,6 +97,7 @@ The function uses these environment variables with sensible defaults:
 | **Prompt Configuration**    |                                       |                            |
 | TURN1_PROMPT_VERSION        | Turn 1 prompt template version        | v1.0                        |
 | TEMPLATE_BASE_PATH          | Path to prompt templates              | /opt/templates              |
+| TEMPLATE_CACHE_ENABLED    | Enable in-memory prompt cache          | true                       |
 
 ---
 

--- a/product-approach/workflow-function/ExecuteTurn2Combined/README.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/README.md
@@ -1,5 +1,6 @@
 # ExecuteTurn2Combined
 
 This Lambda function represents the second phase of the vending machine verification workflow. It loads the checking image, applies a prompt that references the analysis from Turn 1, invokes the LLM via Bedrock and stores the results in S3 and DynamoDB.
+Prompt templates are cached in memory for faster load times. Set `TEMPLATE_CACHE_ENABLED=false` to disable caching.
 
 This directory only provides a skeleton implementation to outline the intended structure. The real implementation should mirror the architecture of `ExecuteTurn1Combined` and make use of the shared packages in `workflow-function/shared`.


### PR DESCRIPTION
## Summary
- drop references to BUDGET_TOKENS and THINKING_TYPE
- note that prompt templates are cached in memory
- document TEMPLATE_CACHE_ENABLED variable

## Testing
- `go test ./...` *(fails: module path issues)*

------
https://chatgpt.com/codex/tasks/task_b_684034104e5c832d8dcfbb0c4c5223ba