### PR TITLE
Fix initialization reference path in helpers

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/CHANGELOG.md
@@ -34,6 +34,13 @@ All notable changes to the ExecuteTurn1Combined function will be documented in t
 - Added missing `anthropic-version` header when invoking Bedrock Converse API.
   Without this header Bedrock returned generic `WRAPPED_ERROR` failures.
 
+## [2.8.9] - 2025-06-09
+### Fixed
+- **Initialization Path**: buildS3RefTree now places `initialization.json` under
+  the `processing` folder when constructing Step Function responses.
+- **Impact**: Ensures FinalizeAndStoreResults can load initialization data
+  successfully.
+
 ## [2.8.7] - 2025-06-05
 ### Changed
 - `NewDynamoDBService` now configures the AWS SDK with adaptive retry mode

--- a/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn1Combined/internal/handler/helpers.go
@@ -90,8 +90,8 @@ func buildS3RefTree(
 		return key
 	}
 
-	// Create initialization reference
-	initRefKey := prefix(fmt.Sprintf("%s/initialization.json", verificationID))
+	// Create initialization reference under processing folder
+	initRefKey := prefix(fmt.Sprintf("%s/processing/initialization.json", verificationID))
 	initRef := models.S3Reference{
 		Bucket: rawRef.Bucket,
 		Key:    initRefKey,

--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -32,6 +32,13 @@ All notable changes to the ExecuteTurn2Combined function will be documented in t
 - Default `THINKING_TYPE` environment variable now set to `enabled` to ensure
   temperature validation passes when `TEMPERATURE=1`.
 
+## [2.2.22] - 2025-06-09
+### Fixed
+- **Initialization Path**: buildTurn2S3RefTree now outputs the correct
+  `processing/initialization.json` path for Step Function responses.
+- **Impact**: Prevents FinalizeAndStoreResults from failing to load initialization
+  data.
+
 
 
 ## [2.2.20] - 2025-06-07

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/helpers.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/handler/helpers.go
@@ -91,8 +91,8 @@ func buildTurn2S3RefTree(
 		return key
 	}
 
-	// Create initialization reference
-	initRefKey := prefix(fmt.Sprintf("%s/initialization.json", verificationID))
+	// Create initialization reference under processing folder
+	initRefKey := prefix(fmt.Sprintf("%s/processing/initialization.json", verificationID))
 	initRef := models.S3Reference{
 		Bucket: rawRef.Bucket,
 		Key:    initRefKey,


### PR DESCRIPTION
## Summary
- put initialization.json under `processing/` when building S3 reference trees
- document change in ExecuteTurn1Combined and ExecuteTurn2Combined changelogs

## Testing
- `go test ./...` *(fails: cannot load module)*

------
https://chatgpt.com/codex/tasks/task_b_68410ad66624832da412766c16b78e8e