### PR TITLE
Fix FinalizeAndStoreResults DynamoDB key usage

### DIFF
--- a/product-approach/workflow-function/FinalizeAndStoreResults/CHANGELOG.md
+++ b/product-approach/workflow-function/FinalizeAndStoreResults/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.1] - 2025-06-05
+### Fixed
+- **Conversation History Update**: `UpdateConversationHistory` now uses both `verificationId` and `conversationAt` keys when updating the `ConversationHistory` table.
+  - Root cause: missing sort key caused `ValidationException` errors during finalization.
+
 ## [1.3.0] - 2025-01-04 - Input Structure Support & S3 Error Resolution
 
 ### Fixed

--- a/product-approach/workflow-function/FinalizeAndStoreResults/cmd/finalizeandstoreresults/main.go
+++ b/product-approach/workflow-function/FinalizeAndStoreResults/cmd/finalizeandstoreresults/main.go
@@ -19,9 +19,9 @@ import (
 )
 
 var (
-	appConfig   *config.LambdaConfig
-	awsClients  *config.AWSClients
-	log         logger.Logger
+	appConfig    *config.LambdaConfig
+	awsClients   *config.AWSClients
+	log          logger.Logger
 	stateManager s3state.Manager
 )
 
@@ -220,11 +220,11 @@ func HandleRequest(ctx context.Context, input interface{}) (*s3state.Envelope, e
 	log.LogReceivedEvent(envelope)
 
 	log.Info("extracted_references", map[string]interface{}{
-		"init_bucket":   initRef.Bucket,
-		"init_key":      initRef.Key,
-		"turn2_bucket":  turn2Ref.Bucket,
-		"turn2_key":     turn2Ref.Key,
-		"turn2_size":    turn2Ref.Size,
+		"init_bucket":  initRef.Bucket,
+		"init_key":     initRef.Key,
+		"turn2_bucket": turn2Ref.Bucket,
+		"turn2_key":    turn2Ref.Key,
+		"turn2_size":   turn2Ref.Size,
 	})
 
 	// Load initialization data using s3state manager
@@ -305,7 +305,7 @@ func HandleRequest(ctx context.Context, input interface{}) (*s3state.Envelope, e
 	}
 
 	// Update conversation history in DynamoDB
-	err = dynamodbhelper.UpdateConversationHistory(ctx, awsClients.DynamoDBClient, appConfig.ConversationHistoryTable, envelope.VerificationID)
+	err = dynamodbhelper.UpdateConversationHistory(ctx, awsClients.DynamoDBClient, appConfig.ConversationHistoryTable, envelope.VerificationID, initData.InitialVerificationAt)
 	if err != nil {
 		wfErr := errors.WrapError(err, errors.ErrorTypeDynamoDB, "failed to update conversation history", false)
 		wfErr.VerificationID = envelope.VerificationID

--- a/product-approach/workflow-function/FinalizeAndStoreResults/internal/dynamodbhelper/dynamodbhelper.go
+++ b/product-approach/workflow-function/FinalizeAndStoreResults/internal/dynamodbhelper/dynamodbhelper.go
@@ -28,11 +28,16 @@ func StoreVerificationResult(ctx context.Context, client *dynamodb.Client, table
 	return nil
 }
 
-func UpdateConversationHistory(ctx context.Context, client *dynamodb.Client, tableName, verificationID string) error {
+func UpdateConversationHistory(ctx context.Context, client *dynamodb.Client, tableName, verificationID, conversationAt string) error {
+	if conversationAt == "" {
+		return errors.NewValidationError("conversationAt required", nil)
+	}
+
 	_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName: &tableName,
 		Key: map[string]types.AttributeValue{
 			"verificationId": &types.AttributeValueMemberS{Value: verificationID},
+			"conversationAt": &types.AttributeValueMemberS{Value: conversationAt},
 		},
 		UpdateExpression: aws.String("SET turnStatus = :ts"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{


### PR DESCRIPTION
## Summary
- ensure conversation history updates use composite key
- pass conversationAt from initialization data
- note fix in FinalizeAndStoreResults changelog

## Testing
- `go test ./...` *(fails: cannot load module ../ExecuteTurn1)*

------
https://chatgpt.com/codex/tasks/task_b_68411003494c832d8db9532870015423