### PR TITLE
Fix DynamoDB update for Turn2 completion

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -39,6 +39,11 @@ All notable changes to the ExecuteTurn2Combined function will be documented in t
 - **Impact**: Prevents FinalizeAndStoreResults from failing to load initialization
   data.
 
+## [2.2.23] - 2025-06-05 - StatusHistory Initialization Fix
+### Fixed
+- `UpdateTurn2CompletionDetails` now initializes `statusHistory` when missing
+  to avoid DynamoDB `ValidationException` errors during update operations.
+
 
 
 ## [2.2.20] - 2025-06-07

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go
@@ -805,7 +805,10 @@ func (d *dynamoClient) updateTurn2CompletionDetailsInternal(
 
 	update := expression.Set(expression.Name("currentStatus"), expression.Value(statusEntry.Status)).
 		Set(expression.Name("lastUpdatedAt"), expression.Value(statusEntry.Timestamp)).
-		Set(expression.Name("statusHistory"), expression.ListAppend(expression.Name("statusHistory"), expression.Value([]types.AttributeValue{&types.AttributeValueMemberM{Value: avStatusEntry}})))
+		Set(expression.Name("statusHistory"), expression.ListAppend(
+			expression.IfNotExists(expression.Name("statusHistory"), expression.Value([]types.AttributeValue{})),
+			expression.Value([]types.AttributeValue{&types.AttributeValueMemberM{Value: avStatusEntry}}),
+		))
 
 	if turn2Metrics != nil {
 		avMetrics, err := attributevalue.MarshalMap(turn2Metrics)


### PR DESCRIPTION
## Summary
- fix UpdateTurn2CompletionDetails to initialize statusHistory when missing
- document fix in changelog

## Testing
- `gofmt -w product-approach/workflow-function/ExecuteTurn2Combined/internal/services/dynamodb.go`


------
https://chatgpt.com/codex/tasks/task_b_684110e35ab8832d804209154ca210fc