### PR TITLE
Add TOP_P config to ExecuteTurn2Combined

### DIFF
--- a/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the ExecuteTurn2Combined function will be documented in this file.
 
+## [2.2.24] - 2025-06-10 - Environment Variable Alignment
+
+### Changed
+- Added `TOP_P` environment variable support (default `0.9`) to match `ExecuteTurn1Combined`.
+- `BEDROCK_MODEL` continues to map to `modelId` in Bedrock requests.
+- Request construction now uses configurable `Temperature` and `TopP` parameters.
+
 ## [2.2.0] - 2025-01-04 - File Extension Fix & Output Compliance
 
 ### Fixed

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter.go
@@ -90,19 +90,22 @@ func (a *Adapter) buildConverseRequest(systemPrompt, turnPrompt, base64Image str
 
 	// Build request using shared package constructor
 	temperature := config.Temperature
+	topP := config.TopP
 	request := sharedBedrock.CreateConverseRequest(
 		config.ModelID,
 		[]sharedBedrock.MessageWrapper{userMessage},
 		systemPrompt,
 		config.MaxTokens,
 		&temperature,
-		nil, // TopP - defer to model defaults
+		&topP, // Use configurable TopP from environment
 	)
 
 	// Log the complete request structure for debugging
 	a.logger.Info("bedrock_request_structure", map[string]interface{}{
-		"model_id":   request.ModelId,
-		"max_tokens": request.InferenceConfig.MaxTokens,
+		"model_id":    request.ModelId,
+		"max_tokens":  request.InferenceConfig.MaxTokens,
+		"temperature": request.InferenceConfig.Temperature,
+		"top_p":       request.InferenceConfig.TopP,
 	})
 
 	// Log the final JSON payload for verification

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/adapter_turn2.go
@@ -174,13 +174,16 @@ func (a *AdapterTurn2) ConverseWithHistory(ctx context.Context, systemPrompt, tu
 		InferenceConfig: sharedBedrock.InferenceConfig{
 			MaxTokens:   a.cfg.Processing.MaxTokens,
 			Temperature: &a.cfg.Processing.Temperature,
+			TopP:        &a.cfg.Processing.TopP,
 		},
 	}
 
 	// Log the complete request structure for debugging
 	a.log.Info("bedrock_request_structure", map[string]interface{}{
-		"model_id":   request.ModelId,
-		"max_tokens": request.InferenceConfig.MaxTokens,
+		"model_id":    request.ModelId,
+		"max_tokens":  request.InferenceConfig.MaxTokens,
+		"temperature": *request.InferenceConfig.Temperature,
+		"top_p":       *request.InferenceConfig.TopP,
 	})
 
 	// Validate request before sending to Bedrock
@@ -332,7 +335,7 @@ func (a *AdapterTurn2) ProcessTurn2(ctx context.Context, systemPrompt, turn2Prom
 	response.ModelConfig = &schema.ModelConfig{
 		ModelId:     a.cfg.AWS.BedrockModel,
 		Temperature: a.cfg.Processing.Temperature,
-		TopP:        0.9, // Default TopP
+		TopP:        a.cfg.Processing.TopP,
 		MaxTokens:   a.cfg.Processing.MaxTokens,
 	}
 

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client.go
@@ -68,6 +68,11 @@ func (c *Client) ValidateConfiguration() error {
 			map[string]interface{}{"current_value": c.config.Temperature})
 	}
 
+	if c.config.TopP < 0 || c.config.TopP > 1 {
+		return errors.NewValidationError("topP must be between 0 and 1",
+			map[string]interface{}{"current_value": c.config.TopP})
+	}
+
 	return nil
 }
 
@@ -77,6 +82,7 @@ func (c *Client) GetOperationalMetrics() map[string]interface{} {
 		"model_id":          c.config.ModelID,
 		"max_tokens":        c.config.MaxTokens,
 		"temperature":       c.config.Temperature,
+		"top_p":             c.config.TopP,
 		"timeout_seconds":   c.config.Timeout.Seconds(),
 		"region":            c.config.Region,
 		"anthropic_version": c.config.AnthropicVersion,

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client_turn2.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/client_turn2.go
@@ -46,6 +46,7 @@ func NewClientTurn2(cfg config.Config, log logger.Logger) (*ClientTurn2, error) 
 		AnthropicVersion: cfg.AWS.AnthropicVersion,
 		MaxTokens:        cfg.Processing.MaxTokens,
 		Temperature:      cfg.Processing.Temperature,
+		TopP:             cfg.Processing.TopP,
 		ThinkingType:     "",
 		ThinkingBudget:   0,
 		Timeout:          time.Duration(cfg.Processing.BedrockCallTimeoutSec) * time.Second,

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/config.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/bedrock/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	AnthropicVersion string
 	MaxTokens        int
 	Temperature      float64
+	TopP             float64
 	ThinkingType     string
 	ThinkingBudget   int
 	Timeout          time.Duration

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Processing struct {
 		MaxTokens                int
 		Temperature              float64
+		TopP                     float64
 		MaxRetries               int
 		BedrockConnectTimeoutSec int
 		BedrockCallTimeoutSec    int
@@ -69,8 +70,8 @@ func LoadConfiguration() (*Config, error) {
 
 	cfg.Processing.MaxTokens = getInt("MAX_TOKENS", 24000)
 
-
 	cfg.Processing.Temperature = getFloat("TEMPERATURE", 0.7)
+	cfg.Processing.TopP = getFloat("TOP_P", 0.9)
 	cfg.Processing.MaxRetries = getInt("MAX_RETRIES", 1)
 	cfg.Processing.BedrockConnectTimeoutSec = getInt("BEDROCK_CONNECT_TIMEOUT_SEC", 10)
 	cfg.Processing.BedrockCallTimeoutSec = getInt("BEDROCK_CALL_TIMEOUT_SEC", 30)
@@ -141,4 +142,3 @@ func (c *Config) DatePartitionFromTimestamp(ts string) (string, error) {
 	t = t.In(loc)
 	return fmt.Sprintf("%04d/%02d/%02d", t.Year(), t.Month(), t.Day()), nil
 }
-

--- a/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/bedrock.go
+++ b/product-approach/workflow-function/ExecuteTurn2Combined/internal/services/bedrock.go
@@ -52,6 +52,7 @@ func NewBedrockService(ctx context.Context, cfg config.Config) (BedrockService, 
 		AnthropicVersion: cfg.AWS.AnthropicVersion,
 		MaxTokens:        cfg.Processing.MaxTokens,
 		Temperature:      cfg.Processing.Temperature,
+		TopP:             cfg.Processing.TopP,
 		ThinkingType:     "",
 		ThinkingBudget:   0,
 		Timeout:          time.Duration(cfg.Processing.BedrockCallTimeoutSec) * time.Second,
@@ -62,9 +63,11 @@ func NewBedrockService(ctx context.Context, cfg config.Config) (BedrockService, 
 	localClient := localBedrock.NewClient(sharedClient, localConfig, log)
 
 	log.Info("bedrock_service_initialized", map[string]interface{}{
-		"model_id":   cfg.AWS.BedrockModel,
-		"region":     cfg.AWS.Region,
-		"max_tokens": cfg.Processing.MaxTokens,
+		"model_id":    cfg.AWS.BedrockModel,
+		"region":      cfg.AWS.Region,
+		"max_tokens":  cfg.Processing.MaxTokens,
+		"temperature": cfg.Processing.Temperature,
+		"top_p":       cfg.Processing.TopP,
 	})
 
 	return &bedrockService{


### PR DESCRIPTION
## Summary
- add `TOP_P` env var support to ExecuteTurn2Combined config
- include TopP in Bedrock config structs and client validation
- use configurable TopP when building Bedrock requests
- log temperature and top_p settings for easier tracing
- document env var alignment in changelog

## Testing
- `go vet ./...` *(fails: cannot load modules)*

------
https://chatgpt.com/codex/tasks/task_b_6841145fe12c832da19b493e706d82df