### PR TITLE
Fix previousVerificationID key handling

### DIFF
--- a/product-approach/workflow-function/FetchImages/CHANGELOG.md
+++ b/product-approach/workflow-function/FetchImages/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.4.2] - 2025-06-09
+
+### Fixed
+- **Compatibility**: Added fallback handling for `previousVerificationID` field
+  name variant to ensure `previousVerificationId` is always recognized
+
+
 ## [4.4.1] - 2025-06-08
 
 ### Fixed


### PR DESCRIPTION
## Summary
- add fallback for `previousVerificationID` when parsing verification context
- document the fix in the FetchImages changelog

## Testing
- `go vet ./...` *(fails: cannot load modules)*

------
https://chatgpt.com/codex/tasks/task_b_68450a89cad4832db8420448a723ae09